### PR TITLE
Declare support for type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ include = ["syntheseus*"]
 exclude = ["syntheseus.tests*"]
 namespaces = false
 
+[tool.setuptools.package-data]
+"syntheseus" = ["py.typed"]
+
 [tool.setuptools_scm]
 
 [tool.black]


### PR DESCRIPTION
As explained [here](https://mypy.readthedocs.io/en/stable/installed_packages.html#installed-packages), packages must explicitly declare they support type checking by creating an empty `py.typed` file (following [PEP 561](https://peps.python.org/pep-0561/)) and making sure it is included in the package data.

After this PR, `mypy` correctly understands the types of things imported from `syntheseus`:

```python
from syntheseus.interface.molecule import Molecule

mol = Molecule("CCC")
reveal_type(mol)
```
```
>>> mypy test.py
test.py:6: note: Revealed type is "syntheseus.interface.molecule.Molecule"
Success: no issues found in 1 source file
```