### PR TITLE
Make interface/models.py run under Python 3.7

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pre-commit
+  - pip:
+    # Optional dependency for the single-step model interface
+    - pydantic>=1.10.5

--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - pre-commit
   - pip:
     # Optional dependency for the single-step model interface
-    - pydantic>=1.10.5
+    - pydantic>=1.10.5  # earlier versions had a bug involving `default_factory` (see https://github.com/pydantic/pydantic/issues/5065)

--- a/syntheseus/interface/models.py
+++ b/syntheseus/interface/models.py
@@ -79,7 +79,6 @@ class PredictionList(GenericModel, Generic[InputType, OutputType]):
 class ReactionModel(Generic[InputType, OutputType]):
     """Base class for all reaction models, both backward and forward."""
 
-    # TODO(krmaziar): Decide how to best handle optional reaction type information.
     @abstractmethod
     def __call__(
         self, inputs: List[InputType], num_results: int

--- a/syntheseus/interface/models.py
+++ b/syntheseus/interface/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from abc import abstractmethod
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 from pydantic import root_validator
 from pydantic.generics import GenericModel
@@ -31,7 +31,7 @@ class Prediction(GenericModel, Generic[InputType, OutputType]):
     score: Optional[float] = None  # Any other score.
     reaction: Optional[str] = None  # Reaction smiles.
     rxnid: Optional[int] = None  # Template id, if applicable.
-    metadata: Optional[dict[str, Any]] = {}  # Additional metadata.
+    metadata: Optional[Dict[str, Any]] = {}  # Additional metadata.
 
     def get_prob(self) -> float:
         if self.probability is not None:
@@ -66,8 +66,8 @@ class PredictionList(GenericModel, Generic[InputType, OutputType]):
         arbitrary_types_allowed = True
 
     input: InputType
-    predictions: list[Prediction[InputType, OutputType]]
-    metadata: Optional[dict[str, Any]] = {}
+    predictions: List[Prediction[InputType, OutputType]]
+    metadata: Optional[Dict[str, Any]] = {}
 
     def truncated(self, num_results: int) -> PredictionList[InputType, OutputType]:
         fields = self.dict()
@@ -82,8 +82,8 @@ class ReactionModel(Generic[InputType, OutputType]):
     # TODO(krmaziar): Decide how to best handle optional reaction type information.
     @abstractmethod
     def __call__(
-        self, inputs: list[InputType], num_results: int
-    ) -> list[PredictionList[InputType, OutputType]]:
+        self, inputs: List[InputType], num_results: int
+    ) -> List[PredictionList[InputType, OutputType]]:
         """Given a batch of inputs to the reaction model, return a batch of results.
 
         Args:

--- a/syntheseus/tests/interface/test_models.py
+++ b/syntheseus/tests/interface/test_models.py
@@ -4,6 +4,9 @@ import numpy as np
 
 from syntheseus.interface.models import Prediction
 
+# TODO(kmaziarz): Currently this test mostly checks that importing from `models.py` works, and that
+# a `Prediction` object can be instantiated. We should extend it later.
+
 
 def test_prediction():
     prediction = Prediction(probability=0.5)

--- a/syntheseus/tests/interface/test_models.py
+++ b/syntheseus/tests/interface/test_models.py
@@ -1,0 +1,11 @@
+import math
+
+import numpy as np
+
+from syntheseus.interface.models import Prediction
+
+
+def test_prediction():
+    prediction = Prediction(probability=0.5)
+    assert np.isclose(prediction.get_prob(), 0.5)
+    assert np.isclose(prediction.get_log_prob(), math.log(0.5))


### PR DESCRIPTION
The generic single-step model interface is not used yet by the search code, and thus also wasn't covered by CI. It turns out it didn't fully work, due to (1) `pydantic` not being present in the environment, and (2) `dict`/`list` not fully working under Python 3.7 in this context. This PR addresses both points and adds a minimal test to cover `models.py`.