### PR TITLE
Pin pydantic version to 1.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Pin `pydantic` version to `1.*` ([#10](https://github.com/microsoft/syntheseus/pull/10)) ([@kmaziarz])
 - Fix compatibility with Python 3.7 ([#5](https://github.com/microsoft/syntheseus/pull/5)) ([@kmaziarz])
 
 ## [0.1.0] - 2023-05-25

--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - pre-commit
   - pip:
     # Optional dependency for the single-step model interface
-    - pydantic>=1.10.5  # earlier versions had a bug involving `default_factory` (see https://github.com/pydantic/pydantic/issues/5065)
+    - pydantic>=1.10.5,<2  # earlier versions had a bug involving `default_factory` (see https://github.com/pydantic/pydantic/issues/5065), later are backward incompatible

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - numpy  # required for some array computing
   - rdkit  # required for molecule objects
   - networkx
-  # Optional dependencies for visuzalization
+  # Optional dependencies for visualization
   - pillow
   - python-graphviz
   # For development


### PR DESCRIPTION
Recently, pydantic 2.0 was released, bringing backward incompatible changes, and breaking our CI:
```python
from pydantic.generics import GenericModel
E   ImportError: cannot import name 'GenericModel' from 'pydantic.generics'
```

In the future we can look into bumping the `pydantic` requirement, but for now we can stick to just pinning `pydantic` to `1.*` as done in this PR.