### PR TITLE
Pin zipp<3.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Pin `pydantic` version to `1.*` ([#10](https://github.com/microsoft/syntheseus/pull/10)) ([@kmaziarz])
 - Fix compatibility with Python 3.7 ([#5](https://github.com/microsoft/syntheseus/pull/5)) ([@kmaziarz])
+- Pin `zipp` version to `<3.16` ([#11](https://github.com/microsoft/syntheseus/pull/11)) ([@kmaziarz])
 
 ## [0.1.0] - 2023-05-25
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,8 @@ dependencies:
   - pytest
   - pytest-cov
   - pre-commit
+  # Temporary pin to avoid the 3.16.0 release, which drops support for Python 3.7
+  - zipp<3.16
   - pip:
     # Optional dependency for the single-step model interface
     - pydantic>=1.10.5,<2  # earlier versions had a bug involving `default_factory` (see https://github.com/pydantic/pydantic/issues/5065), later are backward incompatible


### PR DESCRIPTION
Recently, a library called `zipp` (which we don't depend on directly, but it seems something related to our pre-commit does) released version `3.16`, which dropped support for Python 3.7. It seems that `zipp`'s Python requirement is not correctly picked during installation (see jaraco/zipp#100); this makes our Python 3.7 CI fail as it installs the new version.

In this PR, I pin `zipp<3.16` to get the CI on `main` to pass again. This is not ideal as we don't even depend on `zipp` directly, but I hope it's temporary, and we can remove it once the community sorts things out.