### PR TITLE
Avoid running the security pipeline on every PR

### DIFF
--- a/.github/azure_pipelines/code-security-analysis.yml
+++ b/.github/azure_pipelines/code-security-analysis.yml
@@ -5,6 +5,9 @@ schedules:
     include:
     - main
 
+pr: none
+trigger: none
+
 pool:
  vmImage: 'windows-latest'
 


### PR DESCRIPTION
The security pipeline defined in `azure_pipelines/code-security-analysis.yml` is scheduled to run weekly as required by Microsoft policy. However, it also seems to run on all PRs, which is unnecessary. This PR changes the pipeline's configuration to only do the scheduled runs and not run as part of CI.