### PR TITLE
Change default node depth to infinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Change default node depth to infinity ([#16](https://github.com/microsoft/syntheseus/pull/16)) ([@austint])
 - Pin `pydantic` version to `1.*` ([#10](https://github.com/microsoft/syntheseus/pull/10)) ([@kmaziarz])
 - Fix compatibility with Python 3.7 ([#5](https://github.com/microsoft/syntheseus/pull/5)) ([@kmaziarz])
 - Pin `zipp` version to `<3.16` ([#11](https://github.com/microsoft/syntheseus/pull/11)) ([@kmaziarz])

--- a/syntheseus/search/graph/node.py
+++ b/syntheseus/search/graph/node.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import datetime
+import math
 from collections.abc import Collection
 from dataclasses import dataclass, field
 
@@ -66,8 +67,9 @@ class BaseGraphNode(abc.ABC):
     num_visit: int = 0
 
     # How "deep" is this node, i.e. the length of the path from the root node to this node.
-    # It is initialized to -1 to indicate "not set"; it should be set by algorithms.
-    depth: int = -1
+    # It is initialized to inf to indicate "not set" (and this is the only value which will be
+    # stable with graphs with no root node where depth is ill-defined)
+    depth: int = math.inf  # type: ignore
 
     # Whether the node has been expanded
     is_expanded: bool = False

--- a/syntheseus/tests/search/algorithms/test_base.py
+++ b/syntheseus/tests/search/algorithms/test_base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import datetime
+import math
 import warnings
 
 import pytest
@@ -383,11 +384,13 @@ class BaseAlgorithmTest(abc.ABC):
         # Test on depths
         node_depths = [node.depth for node in output_graph.nodes()]
         if set_depth:
-            assert -1 not in node_depths  # this is the default value which should be overridden
+            assert (
+                math.inf not in node_depths
+            )  # this is the default value which should be overridden
             assert 0 in node_depths  # value for root node
             assert 1 in node_depths
         else:
-            assert -1 in node_depths  # default value should be present
+            assert math.inf in node_depths  # default value should be present
             assert 1 not in node_depths
 
     @pytest.mark.parametrize("prevent", [False, True])


### PR DESCRIPTION
*Background*: Previously a default value of `-1` was assigned to this value, mostly just because it was obviously not a valid depth so it would be clear to users that this is just the default value. However, in some recent experiments with graph algorithms I observed that this could occasionally cause a lot of unnecessary updates when adding a new node to a graph caused a cycle. The depth update uses the minimum depth of any parent, so sometimes the value of -1 was propagated around the graph for a while (giving its children a depth of 0, their children a depth of 1, etc) until this was eventually corrected and all the nodes were updated a second time. Even though each update was short, the cumulative effect was quite large for large graphs: in one experiment with 10k calls to the reaction model, 40min/60min was spent doing these depth updates.

*Rationale*: by changing the default to infinity these redundant updates do not occur because the depth update uses the minimum depth of any parent, so no node in the graph with finite depth will have its depth updated if a node is added whose depth value is set to infinite.

*Alternative considered*: instead of changing the default I could have done very careful updates to ensure that this propagation of -1 never happened (e.g. update the node depths in a correct order). However, changing the default is easier, and infinity is probably a more sensible default value for depth anyway since it would correspond to no valid path to the root node. This value would also be stable if depth updates were run on graphs without a root node.