### PR TITLE
Fix tutorials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Change default node depth to infinity ([#16](https://github.com/microsoft/syntheseus/pull/16)) ([@austint])
-- Adapt tutorials to the renaming from PR #9 ([#17](https://github.com/microsoft/syntheseus/pull/17)) ([@jagarridotorres]) 
+- Adapt tutorials to the renaming from PR #9 ([#17](https://github.com/microsoft/syntheseus/pull/17)) ([@jagarridotorres])
 - Pin `pydantic` version to `1.*` ([#10](https://github.com/microsoft/syntheseus/pull/10)) ([@kmaziarz])
 - Fix compatibility with Python 3.7 ([#5](https://github.com/microsoft/syntheseus/pull/5)) ([@kmaziarz])
 - Pin `zipp` version to `<3.16` ([#11](https://github.com/microsoft/syntheseus/pull/11)) ([@kmaziarz])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Change default node depth to infinity ([#16](https://github.com/microsoft/syntheseus/pull/16)) ([@austint])
+- Adapt tutorials to the renaming from PR #9 ([#17](https://github.com/microsoft/syntheseus/pull/17)) ([@jagarridotorres]) 
 - Pin `pydantic` version to `1.*` ([#10](https://github.com/microsoft/syntheseus/pull/10)) ([@kmaziarz])
 - Fix compatibility with Python 3.7 ([#5](https://github.com/microsoft/syntheseus/pull/5)) ([@kmaziarz])
 - Pin `zipp` version to `<3.16` ([#11](https://github.com/microsoft/syntheseus/pull/11)) ([@kmaziarz])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 [@austint]: https://github.com/AustinT
 [@kmaziarz]: https://github.com/kmaziarz
+[@jagarridotorres]: https://github.com/jagarridotorres

--- a/tutorials/search/1- end to end retrosynthesis with a toy model.ipynb
+++ b/tutorials/search/1- end to end retrosynthesis with a toy model.ipynb
@@ -472,7 +472,7 @@
     "from syntheseus.search.analysis import route_extraction\n",
     "\n",
     "# This iterator returns sets of nodes which constitute synthesis routes\n",
-    "for i, route_nodes in enumerate(iter_routes_cost_order.min_cost_routes(output_graph, max_routes=100)):\n",
+    "for i, route_nodes in enumerate(route_extraction.min_cost_routes(output_graph, max_routes=100)):\n",
     "    visualization.visualize_andor(output_graph, filename=f\"Route {i+1}.pdf\", nodes=route_nodes)"
    ]
   },

--- a/tutorials/search/1- end to end retrosynthesis with a toy model.ipynb
+++ b/tutorials/search/1- end to end retrosynthesis with a toy model.ipynb
@@ -472,7 +472,7 @@
     "from syntheseus.search.analysis import route_extraction\n",
     "\n",
     "# This iterator returns sets of nodes which constitute synthesis routes\n",
-    "for i, route_nodes in enumerate(route_extraction.min_cost_routes(output_graph, max_routes=100)):\n",
+    "for i, route_nodes in enumerate(route_extraction.iter_routes_cost_order(output_graph, max_routes=100)):\n",
     "    visualization.visualize_andor(output_graph, filename=f\"Route {i+1}.pdf\", nodes=route_nodes)"
    ]
   },

--- a/tutorials/search/1- end to end retrosynthesis with a toy model.ipynb
+++ b/tutorials/search/1- end to end retrosynthesis with a toy model.ipynb
@@ -472,7 +472,7 @@
     "from syntheseus.search.analysis import route_extraction\n",
     "\n",
     "# This iterator returns sets of nodes which constitute synthesis routes\n",
-    "for i, route_nodes in enumerate(route_extraction.min_cost_routes(output_graph, max_routes=100)):\n",
+    "for i, route_nodes in enumerate(iter_routes_cost_order.min_cost_routes(output_graph, max_routes=100)):\n",
     "    visualization.visualize_andor(output_graph, filename=f\"Route {i+1}.pdf\", nodes=route_nodes)"
    ]
   },

--- a/tutorials/search/2b- PaRoutes in-depth analysis.ipynb
+++ b/tutorials/search/2b- PaRoutes in-depth analysis.ipynb
@@ -179,7 +179,7 @@
     "from syntheseus.search.analysis import route_extraction\n",
     "alg_name_to_routes = dict()\n",
     "for alg_name, graph in alg_name_to_graph.items():\n",
-    "    routes = list(route_extraction.min_cost_routes(graph, 10_000))\n",
+    "    routes = list(route_extraction.iter_routes_cost_order(graph, 10_000))\n",
     "    print(f\"Found {len(routes)} routes for {alg_name}\", flush=True)\n",
     "    alg_name_to_routes[alg_name] = routes\n",
     "    del routes"


### PR DESCRIPTION
Adapted tutorials to the renaming from PR #9, as they used the old function name `min_cost_routes` instead of `iter_routes_cost_order`.