### PR TITLE
Fix environment setup script for MEGAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Release single-step evaluation framework and wrappers for several model types ([#14](https://github.com/microsoft/syntheseus/pull/14), [#15](https://github.com/microsoft/syntheseus/pull/15)) ([@kmaziarz])
+- Release single-step evaluation framework and wrappers for several model types ([#14](https://github.com/microsoft/syntheseus/pull/14), [#15](https://github.com/microsoft/syntheseus/pull/15), [#20](https://github.com/microsoft/syntheseus/pull/20)) ([@kmaziarz])
 - Add option to terminate search when the first solution is found ([#13](https://github.com/microsoft/syntheseus/pull/13)) ([@austint])
 - Add code to extract routes in order found instead of by minimum cost ([#9](https://github.com/microsoft/syntheseus/pull/9)) ([@austint])
 - Declare support for type checking ([#4](https://github.com/microsoft/syntheseus/pull/4)) ([@kmaziarz])

--- a/syntheseus/reaction_prediction/environments/setup_megan.sh
+++ b/syntheseus/reaction_prediction/environments/setup_megan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install extra dependencies specific to MEGAN.
-pip install gin-config==0.3.0 tensorflow==2.13.0 torchtext==0.13.1
+pip install gin-config==0.3.0 gitpython tensorflow==2.13.0 torchtext==0.11.2 scipy
 
 export GITHUB_ORG_NAME=molecule-one
 export GITHUB_REPO_NAME=megan


### PR DESCRIPTION
There seem to be two issues with `setup_megan.sh` that evaded the testing done in #15:
- Two necessary dependencies (`gitpython` and `scipy`) are missing
- The version of `torchtext` used forces `pip` to switch to a different version of `torch` than the one used in the shared environment

This PR addresses both problems.