### PR TITLE
Release single-step model checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Added
 
 - Release single-step evaluation framework and wrappers for several model types ([#14](https://github.com/microsoft/syntheseus/pull/14), [#15](https://github.com/microsoft/syntheseus/pull/15), [#20](https://github.com/microsoft/syntheseus/pull/20)) ([@kmaziarz])
+- Release checkpoints for all supported single-step model types ([#21](https://github.com/microsoft/syntheseus/pull/21)) ([@kmaziarz])
 - Add option to terminate search when the first solution is found ([#13](https://github.com/microsoft/syntheseus/pull/13)) ([@austint])
 - Add code to extract routes in order found instead of by minimum cost ([#9](https://github.com/microsoft/syntheseus/pull/9)) ([@austint])
 - Declare support for type checking ([#4](https://github.com/microsoft/syntheseus/pull/4)) ([@kmaziarz])

--- a/syntheseus/reaction_prediction/environments/README.md
+++ b/syntheseus/reaction_prediction/environments/README.md
@@ -23,9 +23,27 @@ If you want to use a different one, make sure to edit these two files accordingl
 The GLN model is not compatible with the others, currently requiring a specialized environment creation which includes building `rdkit` from source.
 We packaged all the necessary steps into a Docker environment defined in `gln/Dockerfile`.
 
+## Model checkpoints
+
+See table below for links to model checkpoints trained on USPTO-50K alongside with information on how these checkpoints were obtained.
+Note that all checkpoints were produced in a way that involved external model repositories, hence may be affected by the exact license each model was released with.
+For more details about a particular model see the top of the corresponding model wrapper file in `reaction_prediction/inference/`.
+
+
+| Model checkpoint link                                          | Source |
+|----------------------------------------------------------------|--------|
+| [Chemformer](https://figshare.com/ndownloader/files/42009888)  | finetuned by us starting from checkpoint released by authors |
+| [GLN](https://figshare.com/ndownloader/files/42012720)         | released by authors |
+| [LocalRetro](https://figshare.com/ndownloader/files/42012729)  | trained by us |
+| [MEGAN](https://figshare.com/ndownloader/files/42012732)       | trained by us |
+| [MHNreact](https://figshare.com/ndownloader/files/42012777)    | trained by us |
+| [RetroKNN](https://figshare.com/ndownloader/files/42012786)    | trained by us |
+| [RootAligned](https://figshare.com/ndownloader/files/42012792) | released by authors |
+
 ## Back-translation
 
 In `reaction_prediction/cli/eval.py` a forward model may be used for computing back-translation (round-trip) accuracy.
 Currently, Chemformer is the only supported forward model.
 
 To evaluate a particular model with back-translation computed using Chemformer, simply set up an environment for that model and then run `setup_chemformer.sh` on top.
+See [here](https://figshare.com/ndownloader/files/42012708) for a Chemformer checkpoint finetuned for forward prediction on USPTO-50K. As for the backward direction, pretrained weights released by original authors were used as a starting point.


### PR DESCRIPTION
Continuing from previous PRs (most notably #15), this PR releases trained model checkpoints for all currently integrated baselines.