### PR TITLE
Improve the packing number heuristic used for estimating diversity

### DIFF
--- a/syntheseus/search/analysis/diversity.py
+++ b/syntheseus/search/analysis/diversity.py
@@ -40,8 +40,8 @@ def estimate_packing_number(
         distance_metric: distance between two routes.
         max_packing_number: to avoid expensive computations,
             the algorithm is stopped if a packing number
-            larger than this value is found.
-            If None, the algorithm will run until completion.
+            larger or equal to this value is found.
+            If `None`, the algorithm will run until completion.
         num_tries: the number of random restarts to perform.
         random_state: random state to use for shuffling routes.
 
@@ -115,7 +115,7 @@ def _recursive_construct_packing_set(
         return list(routes)
 
     # Recursive case:
-    # first calculate packing set for both halves
+    # First calculate packing set for both halves
     cutoff_idx = len(routes) // 2
     route_set1 = _recursive_construct_packing_set(
         routes[:cutoff_idx],
@@ -232,10 +232,10 @@ def molecule_symmetric_difference_distance(
     route2: SynthesisGraph,
 ) -> float:
     """
-    Calculate the symmetric difference distance between the sets of reactions in 2 routes.
+    Calculate the symmetric difference distance between the sets of molecules in 2 routes.
     """
 
-    # Get sets of reactions
+    # Get sets of molecules
     molecules1 = _get_molecules(route1)
     molecules2 = _get_molecules(route2)
     return len(molecules1 ^ molecules2)


### PR DESCRIPTION
To estimate the diversity of a set of routes, we currently use a heuristic packing number algorithm which finds the largest set of routes that are sufficiently different from each other (e.g. use non-overlapping reactions).

The current heuristic is _recursive_: to find the best diverse set, it divides the input list of routes into two halves, computes the result recursively, and then greedily combines the solutions. This is then repeated `num_tries` times and the best solution found is returned.

I compared this approach with two alternatives: a simpler _linear_ algorithm that reads the routes left-to-right and tries to greedily extend the solution, and a variant of the recursive algorithm that computes an _optimal_ way of combining the solutions from the recursive calls. To test the three approaches empirically, I took two search runs: a 5-minute run using Retro* + MEGAN, and a 15-minute run using MCTS + LocalRetro; the target molecules were selected so that many diverse routes are found. For each approach I varied the number of trials and tested it on several sets of routes extracted from the searches at various points in time.

In summary, the results are as follows: (1) the simple linear algorithm is faster than the current recursive one and on average finds slightly larger packing sets; (2) the improved recursive algorithm is the slowest per iteration but finds the best packing sets.

In this PR, I propose using the improved recursive algorithm for 10 trials instead of the current one for 100 trials. Empirically this is ~2x faster while finding slightly larger packing sets (~1 extra route in the best packing sets if the input is sufficiently challenging e.g. contains a packing set with 12 or more routes).