### PR TITLE
Add node evaluators that use single-step model probability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Release single-step evaluation framework and wrappers for several model types ([#14](https://github.com/microsoft/syntheseus/pull/14), [#15](https://github.com/microsoft/syntheseus/pull/15), [#20](https://github.com/microsoft/syntheseus/pull/20)) ([@kmaziarz])
 - Release checkpoints for all supported single-step model types ([#21](https://github.com/microsoft/syntheseus/pull/21)) ([@kmaziarz])
+- Implement node evaluators commonly used in MCTS and Retro* ([#23](https://github.com/microsoft/syntheseus/pull/23)) ([@kmaziarz])
 - Add option to terminate search when the first solution is found ([#13](https://github.com/microsoft/syntheseus/pull/13)) ([@austint])
 - Add code to extract routes in order found instead of by minimum cost ([#9](https://github.com/microsoft/syntheseus/pull/9)) ([@austint])
 - Declare support for type checking ([#4](https://github.com/microsoft/syntheseus/pull/4)) ([@kmaziarz])

--- a/syntheseus/search/node_evaluation/base.py
+++ b/syntheseus/search/node_evaluation/base.py
@@ -110,15 +110,15 @@ class ReactionModelBasedEvaluator(NoCacheNodeEvaluator[NodeType]):
                 `temperature != 1.0`.
             temperature: Temperature to apply (i.e. divide the logits by).
             clip_probability_min: Minimum probability to clip to. Should be positive if `return_log`
-                is set to avoid NaNs.
+                or `normalize` is set to avoid NaNs.
             clip_probability_max: Maximum probability to clip to.
         """
         super().__init__()
 
         assert 0.0 <= clip_probability_min <= clip_probability_max <= 1.0
 
-        if return_log and clip_probability_min == 0.0:
-            raise ValueError("Disabling clipping can lead to NaNs when computing log probability")
+        if (return_log or normalize) and clip_probability_min == 0.0:
+            raise ValueError("Disabling clipping can lead to NaNs")
 
         self._return_log = return_log
         self._normalize = normalize

--- a/syntheseus/search/node_evaluation/base.py
+++ b/syntheseus/search/node_evaluation/base.py
@@ -87,7 +87,10 @@ class NoCacheNodeEvaluator(BaseNodeEvaluator[NodeType]):
 
 
 class ReactionModelBasedEvaluator(NoCacheNodeEvaluator[NodeType]):
-    """Evaluator that computes its value based on the probability from the single-step model."""
+    """
+    Evaluator that computes its value based on the `probability` metadata from the underlying
+    reaction objects (with optional clipping and normalization).
+    """
 
     def __init__(
         self,
@@ -103,8 +106,8 @@ class ReactionModelBasedEvaluator(NoCacheNodeEvaluator[NodeType]):
             return_log: Whether to return the logarithm of the probability instead of the
                 probability itself.
             normalize: Whether to renormalize the output to be a distribution (or logarithms of
-                probabilities corresponding to a valid distribution). This is mostly useful when
-                `temperature != 1.0`, as otherwise the inputs would typically be normalized.
+                probabilities corresponding to a valid distribution). This is especially useful when
+                `temperature != 1.0`.
             temperature: Temperature to apply (i.e. divide the logits by).
             clip_probability_min: Minimum probability to clip to. Should be positive if `return_log`
                 is set to avoid NaNs.

--- a/syntheseus/search/node_evaluation/base.py
+++ b/syntheseus/search/node_evaluation/base.py
@@ -92,7 +92,6 @@ class ReactionModelBasedEvaluator(NoCacheNodeEvaluator[NodeType]):
     def __init__(
         self,
         return_log: bool,
-        return_negated: bool,
         normalize: bool = False,
         temperature: float = 1.0,
         clip_probability_min: float = 1e-10,
@@ -103,7 +102,6 @@ class ReactionModelBasedEvaluator(NoCacheNodeEvaluator[NodeType]):
         Args:
             return_log: Whether to return the logarithm of the probability instead of the
                 probability itself.
-            return_negated: Whether to multiply the result by `-1`.
             normalize: Whether to renormalize the output to be a distribution (or logarithms of
                 probabilities corresponding to a valid distribution). This is mostly useful when
                 `temperature != 1.0`, as otherwise the inputs would typically be normalized.
@@ -120,7 +118,6 @@ class ReactionModelBasedEvaluator(NoCacheNodeEvaluator[NodeType]):
             raise ValueError("Disabling clipping can lead to NaNs when computing log probability")
 
         self._return_log = return_log
-        self._return_negated = return_negated
         self._normalize = normalize
         self._temperature = temperature
         self._clip_probability_min = clip_probability_min
@@ -154,8 +151,5 @@ class ReactionModelBasedEvaluator(NoCacheNodeEvaluator[NodeType]):
             outputs = probs ** (1.0 / self._temperature)
             if self._normalize:
                 outputs /= outputs.sum()
-
-        if self._return_negated:
-            outputs *= -1.0
 
         return outputs.tolist()

--- a/syntheseus/search/node_evaluation/common.py
+++ b/syntheseus/search/node_evaluation/common.py
@@ -38,20 +38,9 @@ class ReactionModelLogProbCost(ReactionModelBasedEvaluator[AndNode]):
 class ReactionModelProbPolicy(ReactionModelBasedEvaluator[MolSetNode]):
     """Evaluator that uses the reactions' probability to form a policy (useful for OR-MCTS)."""
 
-    def __init__(
-        self,
-        normalize: bool = True,
-        clip_probability_min: float = 0.0,
-        clip_probability_max: float = 1.0,
-        **kwargs,
-    ) -> None:
-        super().__init__(
-            return_log=False,
-            normalize=normalize,
-            clip_probability_min=clip_probability_min,
-            clip_probability_max=clip_probability_max,
-            **kwargs,
-        )
+    def __init__(self, **kwargs) -> None:
+        kwargs["normalize"] = kwargs.get("normalize", True)  # set `normalize = True` by default
+        super().__init__(return_log=False, **kwargs)
 
     def _get_reaction(self, node: MolSetNode, graph) -> BackwardReaction:
         parents = list(graph.predecessors(node))

--- a/syntheseus/search/node_evaluation/common.py
+++ b/syntheseus/search/node_evaluation/common.py
@@ -23,6 +23,8 @@ class HasSolutionValueFunction(NoCacheNodeEvaluator):
 
 
 class ReactionModelLogProbCost(ReactionModelBasedEvaluator[AndNode]):
+    """Evaluator that uses the reactions' negative logprob to form a cost (useful for Retro*)."""
+
     def __init__(self, **kwargs) -> None:
         super().__init__(return_log=True, **kwargs)
 
@@ -34,6 +36,8 @@ class ReactionModelLogProbCost(ReactionModelBasedEvaluator[AndNode]):
 
 
 class ReactionModelProbPolicy(ReactionModelBasedEvaluator[MolSetNode]):
+    """Evaluator that uses the reactions' probability to form a policy (useful for OR-MCTS)."""
+
     def __init__(
         self,
         normalize: bool = True,

--- a/syntheseus/search/node_evaluation/common.py
+++ b/syntheseus/search/node_evaluation/common.py
@@ -1,6 +1,9 @@
 """Common node evaluation functions."""
 
-from syntheseus.search.node_evaluation.base import NoCacheNodeEvaluator
+from syntheseus.search.chem import BackwardReaction
+from syntheseus.search.graph.and_or import AndNode
+from syntheseus.search.graph.molset import MolSetNode
+from syntheseus.search.node_evaluation.base import NoCacheNodeEvaluator, ReactionModelBasedEvaluator
 
 
 class ConstantNodeEvaluator(NoCacheNodeEvaluator):
@@ -15,3 +18,30 @@ class ConstantNodeEvaluator(NoCacheNodeEvaluator):
 class HasSolutionValueFunction(NoCacheNodeEvaluator):
     def _evaluate_nodes(self, nodes, graph=None):
         return [float(n.has_solution) for n in nodes]
+
+
+class ReactionModelLogProbCost(ReactionModelBasedEvaluator[AndNode]):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(return_log=True, return_negated=True, **kwargs)
+
+    def _get_reaction(self, node: AndNode, graph) -> BackwardReaction:
+        return node.reaction
+
+
+class ReactionModelProbPolicy(ReactionModelBasedEvaluator[MolSetNode]):
+    def __init__(
+        self, clip_probability_min: float = 0.0, clip_probability_max: float = 1.0, **kwargs
+    ) -> None:
+        super().__init__(
+            return_log=False,
+            return_negated=False,
+            clip_probability_min=clip_probability_min,
+            clip_probability_max=clip_probability_max,
+            **kwargs,
+        )
+
+    def _get_reaction(self, node: MolSetNode, graph) -> BackwardReaction:
+        parents = list(graph.predecessors(node))
+        assert len(parents) == 1, "Graph must be a tree"
+
+        return graph._graph.edges[parents[0], node]["reaction"]

--- a/syntheseus/search/node_evaluation/common.py
+++ b/syntheseus/search/node_evaluation/common.py
@@ -1,5 +1,7 @@
 """Common node evaluation functions."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 
 from syntheseus.search.chem import BackwardReaction

--- a/syntheseus/search/node_evaluation/common.py
+++ b/syntheseus/search/node_evaluation/common.py
@@ -1,5 +1,7 @@
 """Common node evaluation functions."""
 
+from collections.abc import Sequence
+
 from syntheseus.search.chem import BackwardReaction
 from syntheseus.search.graph.and_or import AndNode
 from syntheseus.search.graph.molset import MolSetNode
@@ -22,10 +24,13 @@ class HasSolutionValueFunction(NoCacheNodeEvaluator):
 
 class ReactionModelLogProbCost(ReactionModelBasedEvaluator[AndNode]):
     def __init__(self, **kwargs) -> None:
-        super().__init__(return_log=True, return_negated=True, **kwargs)
+        super().__init__(return_log=True, **kwargs)
 
     def _get_reaction(self, node: AndNode, graph) -> BackwardReaction:
         return node.reaction
+
+    def _evaluate_nodes(self, nodes, graph=None) -> Sequence[float]:
+        return [-v for v in super()._evaluate_nodes(nodes, graph)]
 
 
 class ReactionModelProbPolicy(ReactionModelBasedEvaluator[MolSetNode]):
@@ -38,7 +43,6 @@ class ReactionModelProbPolicy(ReactionModelBasedEvaluator[MolSetNode]):
     ) -> None:
         super().__init__(
             return_log=False,
-            return_negated=False,
             normalize=normalize,
             clip_probability_min=clip_probability_min,
             clip_probability_max=clip_probability_max,

--- a/syntheseus/search/node_evaluation/common.py
+++ b/syntheseus/search/node_evaluation/common.py
@@ -34,7 +34,7 @@ class ReactionModelProbPolicy(ReactionModelBasedEvaluator[MolSetNode]):
         normalize: bool = True,
         clip_probability_min: float = 0.0,
         clip_probability_max: float = 1.0,
-        **kwargs
+        **kwargs,
     ) -> None:
         super().__init__(
             return_log=False,

--- a/syntheseus/search/node_evaluation/common.py
+++ b/syntheseus/search/node_evaluation/common.py
@@ -30,11 +30,16 @@ class ReactionModelLogProbCost(ReactionModelBasedEvaluator[AndNode]):
 
 class ReactionModelProbPolicy(ReactionModelBasedEvaluator[MolSetNode]):
     def __init__(
-        self, clip_probability_min: float = 0.0, clip_probability_max: float = 1.0, **kwargs
+        self,
+        normalize: bool = True,
+        clip_probability_min: float = 0.0,
+        clip_probability_max: float = 1.0,
+        **kwargs
     ) -> None:
         super().__init__(
             return_log=False,
             return_negated=False,
+            normalize=normalize,
             clip_probability_min=clip_probability_min,
             clip_probability_max=clip_probability_max,
             **kwargs,

--- a/syntheseus/tests/search/node_evaluation/test_common.py
+++ b/syntheseus/tests/search/node_evaluation/test_common.py
@@ -79,13 +79,13 @@ class TestReactionModelLogProbCost:
 
     def test_enforces_min_clipping(self) -> None:
         with pytest.raises(ValueError):
-            ReactionModelLogProbCost(clip_probability_min=0.0)
+            ReactionModelLogProbCost(clip_probability_min=0.0)  # should fail as `return_log = True`
 
 
 class TestReactionModelProbPolicy:
     @pytest.mark.parametrize("normalize", [False, True])
     @pytest.mark.parametrize("temperature", [1.0, 2.0])
-    @pytest.mark.parametrize("clip_probability_min", [0.0, 0.5])
+    @pytest.mark.parametrize("clip_probability_min", [0.1, 0.5])
     @pytest.mark.parametrize("clip_probability_max", [0.5, 1.0])
     def test_values(
         self,
@@ -136,3 +136,11 @@ class TestReactionModelProbPolicy:
         assert (
             val_fn.num_calls == len(molset_tree_non_minimal) - 1
         )  # should have been called once per non-root node
+
+    def test_enforces_min_clipping(self) -> None:
+        with pytest.raises(ValueError):
+            ReactionModelProbPolicy(clip_probability_min=0.0)  # should fail as `normalize = True`
+
+        ReactionModelProbPolicy(
+            normalize=False, clip_probability_min=0.0
+        )  # should succeed if we explicitly turn off normalization

--- a/syntheseus/tests/search/node_evaluation/test_common.py
+++ b/syntheseus/tests/search/node_evaluation/test_common.py
@@ -1,9 +1,14 @@
+import math
+
 import pytest
 
-from syntheseus.search.graph.and_or import AndOrGraph
+from syntheseus.search.graph.and_or import AndNode, AndOrGraph
+from syntheseus.search.graph.molset import MolSetGraph
 from syntheseus.search.node_evaluation.common import (
     ConstantNodeEvaluator,
     HasSolutionValueFunction,
+    ReactionModelLogProbCost,
+    ReactionModelProbPolicy,
 )
 
 
@@ -27,3 +32,91 @@ class TestHasSolutionValueFunction:
         assert val_fn.num_calls == len(
             andor_graph_non_minimal
         )  # should have been called once per node
+
+
+class TestReactionModelLogProbCost:
+    @pytest.mark.parametrize("temperature", [1.0, 2.0])
+    @pytest.mark.parametrize("clip_probability_min", [0.1, 0.5])
+    @pytest.mark.parametrize("clip_probability_max", [0.5, 1.0])
+    def test_values(
+        self,
+        andor_graph_non_minimal: AndOrGraph,
+        temperature: float,
+        clip_probability_min: float,
+        clip_probability_max: float,
+    ) -> None:
+        val_fn = ReactionModelLogProbCost(
+            temperature=temperature,
+            clip_probability_min=clip_probability_min,
+            clip_probability_max=clip_probability_max,
+        )
+        nodes = [node for node in andor_graph_non_minimal.nodes() if isinstance(node, AndNode)]
+
+        # The toy model does not set reaction probabilities, so set these manually.
+        node_prob = {}
+        for idx, node in enumerate(nodes):
+            node_prob[node] = idx / (len(nodes) - 1)
+            node.reaction.metadata["probability"] = node_prob[node]  # type: ignore
+
+        vals = val_fn(nodes)
+        for val_computed, node in zip(vals, nodes):  # values should match
+            prob = node_prob[node]
+            val_expected = (
+                -math.log(min(clip_probability_max, max(clip_probability_min, prob))) / temperature
+            )
+
+            assert math.isclose(val_computed, val_expected)
+
+        assert val_fn.num_calls == len(nodes)  # should have been called once per AND node
+
+    def test_enforces_min_clipping(self) -> None:
+        with pytest.raises(ValueError):
+            ReactionModelLogProbCost(clip_probability_min=0.0)
+
+
+class TestReactionModelProbPolicy:
+    @pytest.mark.parametrize("temperature", [1.0, 2.0])
+    @pytest.mark.parametrize("clip_probability_min", [0.0, 0.5])
+    @pytest.mark.parametrize("clip_probability_max", [0.5, 1.0])
+    def test_values(
+        self,
+        molset_tree_non_minimal: MolSetGraph,
+        temperature: float,
+        clip_probability_min: float,
+        clip_probability_max: float,
+    ) -> None:
+        val_fn = ReactionModelProbPolicy(
+            temperature=temperature,
+            clip_probability_min=clip_probability_min,
+            clip_probability_max=clip_probability_max,
+        )
+        nodes = [
+            node
+            for node in molset_tree_non_minimal.nodes()
+            if node != molset_tree_non_minimal.root_node
+        ]
+
+        # The toy model does not set reaction probabilities, so set these manually.
+        node_prob = {}
+        for idx, node in enumerate(nodes):
+            [parent] = molset_tree_non_minimal.predecessors(node)
+            reaction = molset_tree_non_minimal._graph.edges[parent, node]["reaction"]
+
+            # Be careful not to overwrite things as some reactions in the graph are repeated.
+            if "probability" not in reaction.metadata:
+                reaction.metadata["probability"] = node_prob[node] = idx / (len(nodes) - 1)
+            else:
+                node_prob[node] = reaction.metadata["probability"]
+
+        vals = val_fn(nodes, graph=molset_tree_non_minimal)
+        for val_computed, node in zip(vals, nodes):  # values should match
+            prob = node_prob[node]
+            val_expected = min(clip_probability_max, max(clip_probability_min, prob)) ** (
+                1.0 / temperature
+            )
+
+            assert math.isclose(val_computed, val_expected)
+
+        assert (
+            val_fn.num_calls == len(molset_tree_non_minimal) - 1
+        )  # should have been called once per non-root node

--- a/syntheseus/tests/search/node_evaluation/test_common.py
+++ b/syntheseus/tests/search/node_evaluation/test_common.py
@@ -35,17 +35,20 @@ class TestHasSolutionValueFunction:
 
 
 class TestReactionModelLogProbCost:
+    @pytest.mark.parametrize("normalize", [False, True])
     @pytest.mark.parametrize("temperature", [1.0, 2.0])
     @pytest.mark.parametrize("clip_probability_min", [0.1, 0.5])
     @pytest.mark.parametrize("clip_probability_max", [0.5, 1.0])
     def test_values(
         self,
         andor_graph_non_minimal: AndOrGraph,
+        normalize: bool,
         temperature: float,
         clip_probability_min: float,
         clip_probability_max: float,
     ) -> None:
         val_fn = ReactionModelLogProbCost(
+            normalize=normalize,
             temperature=temperature,
             clip_probability_min=clip_probability_min,
             clip_probability_max=clip_probability_max,
@@ -53,19 +56,24 @@ class TestReactionModelLogProbCost:
         nodes = [node for node in andor_graph_non_minimal.nodes() if isinstance(node, AndNode)]
 
         # The toy model does not set reaction probabilities, so set these manually.
-        node_prob = {}
+        node_val_expected = {}
         for idx, node in enumerate(nodes):
-            node_prob[node] = idx / (len(nodes) - 1)
-            node.reaction.metadata["probability"] = node_prob[node]  # type: ignore
+            prob = idx / (len(nodes) - 1)
+            node.reaction.metadata["probability"] = prob  # type: ignore
 
-        vals = val_fn(nodes)
-        for val_computed, node in zip(vals, nodes):  # values should match
-            prob = node_prob[node]
-            val_expected = (
+            node_val_expected[node] = (
                 -math.log(min(clip_probability_max, max(clip_probability_min, prob))) / temperature
             )
 
-            assert math.isclose(val_computed, val_expected)
+        if normalize:
+            normalization_constant = math.log(sum(math.exp(-v) for v in node_val_expected.values()))
+            node_val_expected = {
+                key: value + normalization_constant for key, value in node_val_expected.items()
+            }
+
+        vals = val_fn(nodes)
+        for val_computed, node in zip(vals, nodes):  # values should match
+            assert math.isclose(val_computed, node_val_expected[node])
 
         assert val_fn.num_calls == len(nodes)  # should have been called once per AND node
 
@@ -75,17 +83,20 @@ class TestReactionModelLogProbCost:
 
 
 class TestReactionModelProbPolicy:
+    @pytest.mark.parametrize("normalize", [False, True])
     @pytest.mark.parametrize("temperature", [1.0, 2.0])
     @pytest.mark.parametrize("clip_probability_min", [0.0, 0.5])
     @pytest.mark.parametrize("clip_probability_max", [0.5, 1.0])
     def test_values(
         self,
         molset_tree_non_minimal: MolSetGraph,
+        normalize: bool,
         temperature: float,
         clip_probability_min: float,
         clip_probability_max: float,
     ) -> None:
         val_fn = ReactionModelProbPolicy(
+            normalize=normalize,
             temperature=temperature,
             clip_probability_min=clip_probability_min,
             clip_probability_max=clip_probability_max,
@@ -97,25 +108,30 @@ class TestReactionModelProbPolicy:
         ]
 
         # The toy model does not set reaction probabilities, so set these manually.
-        node_prob = {}
+        node_val_expected = {}
         for idx, node in enumerate(nodes):
             [parent] = molset_tree_non_minimal.predecessors(node)
             reaction = molset_tree_non_minimal._graph.edges[parent, node]["reaction"]
 
             # Be careful not to overwrite things as some reactions in the graph are repeated.
             if "probability" not in reaction.metadata:
-                reaction.metadata["probability"] = node_prob[node] = idx / (len(nodes) - 1)
+                reaction.metadata["probability"] = prob = idx / (len(nodes) - 1)
             else:
-                node_prob[node] = reaction.metadata["probability"]
+                prob = reaction.metadata["probability"]
+
+            node_val_expected[node] = min(
+                clip_probability_max, max(clip_probability_min, prob)
+            ) ** (1.0 / temperature)
+
+        if normalize:
+            normalization_factor = sum(node_val_expected.values())
+            node_val_expected = {
+                key: value / normalization_factor for key, value in node_val_expected.items()
+            }
 
         vals = val_fn(nodes, graph=molset_tree_non_minimal)
         for val_computed, node in zip(vals, nodes):  # values should match
-            prob = node_prob[node]
-            val_expected = min(clip_probability_max, max(clip_probability_min, prob)) ** (
-                1.0 / temperature
-            )
-
-            assert math.isclose(val_computed, val_expected)
+            assert math.isclose(val_computed, node_val_expected[node])
 
         assert (
             val_fn.num_calls == len(molset_tree_non_minimal) - 1


### PR DESCRIPTION
In practical experiments, it is often useful to guide the search using the probabilities assigned by the single-step model, plugging them in either through a node value function or a search policy. This PR adds flexible node evaluators that enable this functionality.

The classes added here are covered by new tests in `node_evaluation/test_common.py`. However, graphs available as standard test fixtures in the codebase could not be used out-of-the-box as these graphs do not have single-step model probability metadata set. This is because they were produced using a `search`-style reaction model, whereas probability is only set by models wrapped with `SyntheseusBackwardReactionModel`. For now I adjusted the fixtures ad-hoc in the respective tests, but this discrepancy suggests that we might want to rethink how `search` and `reaction_prediction` interact.