### PR TITLE
Fix error in graph standardization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed bug where standardizing MolSetGraphs crashed ([#24](https://github.com/microsoft/syntheseus/pull/24)) ([@austint])
 - Change default node depth to infinity ([#16](https://github.com/microsoft/syntheseus/pull/16)) ([@austint])
 - Adapt tutorials to the renaming from PR #9 ([#17](https://github.com/microsoft/syntheseus/pull/17)) ([@jagarridotorres])
 - Pin `pydantic` version to `1.*` ([#10](https://github.com/microsoft/syntheseus/pull/10)) ([@kmaziarz])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed bug where standardizing MolSetGraphs crashed ([#24](https://github.com/microsoft/syntheseus/pull/24)) ([@austint])
+- Fix bug where standardizing MolSetGraphs crashed ([#24](https://github.com/microsoft/syntheseus/pull/24)) ([@austint])
 - Change default node depth to infinity ([#16](https://github.com/microsoft/syntheseus/pull/16)) ([@austint])
 - Adapt tutorials to the renaming from PR #9 ([#17](https://github.com/microsoft/syntheseus/pull/17)) ([@jagarridotorres])
 - Pin `pydantic` version to `1.*` ([#10](https://github.com/microsoft/syntheseus/pull/10)) ([@kmaziarz])

--- a/syntheseus/search/graph/standardization.py
+++ b/syntheseus/search/graph/standardization.py
@@ -106,7 +106,7 @@ def _unique_node_andor_from_molset(
     # Get all mols and reactions
     all_nodes: set[MolSetNode] = set(graph._graph.nodes())
     mols = set(mol for node in all_nodes for mol in node.mols)
-    rxns = set(edge["reaction"] for edge in graph._graph.edges())
+    rxns = set(graph._graph.edges[n1, n2]["reaction"] for n1, n2 in graph._graph.edges())
 
     # Make initial nodes
     mol_to_node = {mol: OrNode(mol) for mol in mols}

--- a/syntheseus/tests/search/graph/test_standardization.py
+++ b/syntheseus/tests/search/graph/test_standardization.py
@@ -11,17 +11,13 @@ from syntheseus.search.graph.molset import MolSetGraph
 from syntheseus.search.graph.standardization import get_unique_node_andor_graph
 
 
-def test_smoke_andor(
-    andor_graph_non_minimal: AndOrGraph,
-):
+def test_smoke_andor(andor_graph_non_minimal: AndOrGraph):
     with pytest.warns(UserWarning):
         output = get_unique_node_andor_graph(andor_graph_non_minimal)
 
     assert len(output) == len(andor_graph_non_minimal)  # no nodes deleted here
 
 
-def test_smoke_molset(
-    molset_tree_non_minimal: MolSetGraph,
-):
+def test_smoke_molset(molset_tree_non_minimal: MolSetGraph):
     with pytest.warns(UserWarning):
         get_unique_node_andor_graph(molset_tree_non_minimal)

--- a/syntheseus/tests/search/graph/test_standardization.py
+++ b/syntheseus/tests/search/graph/test_standardization.py
@@ -1,1 +1,27 @@
-"""Graph standardization is not tested at this time, but should be tested in the future."""
+"""
+At the moment, only a smoke-test is done for graph standardization,
+but the exact behaviour is not well-tested.
+These tests should be added in the future.
+"""
+
+import pytest
+
+from syntheseus.search.graph.and_or import AndOrGraph
+from syntheseus.search.graph.molset import MolSetGraph
+from syntheseus.search.graph.standardization import get_unique_node_andor_graph
+
+
+def test_smoke_andor(
+    andor_graph_non_minimal: AndOrGraph,
+):
+    with pytest.warns(UserWarning):
+        output = get_unique_node_andor_graph(andor_graph_non_minimal)
+
+    assert len(output) == len(andor_graph_non_minimal)  # no nodes deleted here
+
+
+def test_smoke_molset(
+    molset_tree_non_minimal: MolSetGraph,
+):
+    with pytest.warns(UserWarning):
+        get_unique_node_andor_graph(molset_tree_non_minimal)


### PR DESCRIPTION
The initial release included a file `syntheseus/search/graph/standardization.py` which contained code to turn all types of graphs into minimal AND/OR graphs (i.e. AND/OR graphs with one node per reaction and one node per molecule). 
It turns out that for MolSetGraph objects the code to fetch the reaction objects was incorrect and would crash. I didn't catch this before because I didn't actually write tests for this file.

This PR fixes this bug, and adds minimal "smoke" tests to make sure that this method runs without crashing. However, the actual output is not tested. To reflect this, the method still raises a warning when it is called.