### PR TITLE
Add a time limit multiplier to all algorithm base tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Added option to override time tolerance in algorithm tests ([#25](https://github.com/microsoft/syntheseus/pull/25)) ([@austint])
 - Improve the heuristic used for estimating diversity ([#22](https://github.com/microsoft/syntheseus/pull/22)) ([@kmaziarz])
 - Improve the aesthetics of `README.md` ([#19](https://github.com/microsoft/syntheseus/pull/19)) ([@kmaziarz])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Added option to override time tolerance in algorithm tests ([#25](https://github.com/microsoft/syntheseus/pull/25)) ([@austint])
+- Add option to override time tolerance in algorithm tests ([#25](https://github.com/microsoft/syntheseus/pull/25)) ([@austint])
 - Improve the heuristic used for estimating diversity ([#22](https://github.com/microsoft/syntheseus/pull/22)) ([@kmaziarz])
 - Improve the aesthetics of `README.md` ([#19](https://github.com/microsoft/syntheseus/pull/19)) ([@kmaziarz])
 

--- a/syntheseus/tests/search/algorithms/test_base.py
+++ b/syntheseus/tests/search/algorithms/test_base.py
@@ -30,6 +30,7 @@ class BaseAlgorithmTest(abc.ABC):
 
     # Some tolerances for tests
     time_limit_upper_bound_s = 0.05
+    time_limit_multiplier = 1.0  # can be overridden by subclasses for slower algorithms
 
     @abc.abstractmethod
     def setup_algorithm(self, **kwargs) -> SearchAlgorithm:
@@ -63,7 +64,7 @@ class BaseAlgorithmTest(abc.ABC):
         alg = self.setup_algorithm(
             reaction_model=retrosynthesis_task1.reaction_model,
             mol_inventory=retrosynthesis_task1.inventory,
-            time_limit_s=0.1,
+            time_limit_s=0.1 * self.time_limit_multiplier,
             limit_iterations=1_000,
             limit_reaction_model_calls=10,
         )
@@ -86,7 +87,7 @@ class BaseAlgorithmTest(abc.ABC):
             reaction_model=retrosynthesis_task4.reaction_model,
             mol_inventory=retrosynthesis_task4.inventory,
             limit_iterations=10_000,
-            time_limit_s=0.1,
+            time_limit_s=0.1 * self.time_limit_multiplier,
         )
         output_graph, _ = alg.run_from_mol(retrosynthesis_task4.target_mol)
         assert output_graph.root_node.has_solution
@@ -139,7 +140,8 @@ class BaseAlgorithmTest(abc.ABC):
         alg = self.setup_algorithm(
             reaction_model=retrosynthesis_task1.reaction_model,
             mol_inventory=retrosynthesis_task1.inventory,
-            time_limit_s=1e3,  # set a finite but extremely large limit to avoid warnings
+            time_limit_s=1e3
+            * self.time_limit_multiplier,  # set a finite but extremely large limit to avoid warnings
             limit_iterations=INT_INF,
             limit_reaction_model_calls=limit,
         )
@@ -214,7 +216,7 @@ class BaseAlgorithmTest(abc.ABC):
         alg = self.setup_algorithm(
             reaction_model=retrosynthesis_task1.reaction_model,
             mol_inventory=retrosynthesis_task1.inventory,
-            time_limit_s=0.2,
+            time_limit_s=0.2 * self.time_limit_multiplier,
             limit_iterations=10_000,
             limit_reaction_model_calls=1_000,
             max_expansion_depth=depth,
@@ -242,7 +244,7 @@ class BaseAlgorithmTest(abc.ABC):
         alg = self.setup_algorithm(
             reaction_model=retrosynthesis_task1.reaction_model,
             mol_inventory=retrosynthesis_task1.inventory,
-            time_limit_s=0.1,
+            time_limit_s=0.1 * self.time_limit_multiplier,
             limit_iterations=10_000,
             limit_reaction_model_calls=1_000,
             max_expansion_depth=4,
@@ -292,7 +294,7 @@ class BaseAlgorithmTest(abc.ABC):
             alg = self.setup_algorithm(
                 reaction_model=retrosynthesis_task5.reaction_model,
                 mol_inventory=retrosynthesis_task5.inventory,
-                time_limit_s=0.1,
+                time_limit_s=0.1 * self.time_limit_multiplier,
                 limit_iterations=10_000,
                 limit_reaction_model_calls=100,
                 max_expansion_depth=10,
@@ -344,7 +346,7 @@ class BaseAlgorithmTest(abc.ABC):
             reaction_model=retrosynthesis_task4.reaction_model,
             mol_inventory=retrosynthesis_task4.inventory,
             limit_iterations=10_000,
-            time_limit_s=0.1,
+            time_limit_s=0.1 * self.time_limit_multiplier,
             set_has_solution=set_has_solution,
         )
         output_graph, _ = alg.run_from_mol(retrosynthesis_task4.target_mol)
@@ -376,7 +378,7 @@ class BaseAlgorithmTest(abc.ABC):
             reaction_model=retrosynthesis_task4.reaction_model,
             mol_inventory=retrosynthesis_task4.inventory,
             limit_iterations=10_000,
-            time_limit_s=0.1,
+            time_limit_s=0.1 * self.time_limit_multiplier,
             set_depth=set_depth,
         )
         output_graph, _ = alg.run_from_mol(retrosynthesis_task4.target_mol)
@@ -422,7 +424,7 @@ class BaseAlgorithmTest(abc.ABC):
         alg = self.setup_algorithm(
             reaction_model=retrosynthesis_task5.reaction_model,
             mol_inventory=SmilesListInventory([]),
-            time_limit_s=10.0,
+            time_limit_s=10.0 * self.time_limit_multiplier,
             limit_iterations=1_000,
             limit_reaction_model_calls=100,
             prevent_repeat_mol_in_trees=prevent,
@@ -478,7 +480,9 @@ class BaseAlgorithmTest(abc.ABC):
         """Test that the correct routes are found for a simple example."""
 
         route_objs = self._run_alg_and_extract_routes(
-            retrosynthesis_task1, time_limit_s=0.1, limit_iterations=10_000
+            retrosynthesis_task1,
+            time_limit_s=0.1 * self.time_limit_multiplier,
+            limit_iterations=10_000,
         )
         assert len(route_objs) > 2  # should find AT LEAST this many routes
 
@@ -491,7 +495,9 @@ class BaseAlgorithmTest(abc.ABC):
         """Test that correct routes are found for a more complex example."""
 
         route_objs = self._run_alg_and_extract_routes(
-            retrosynthesis_task2, time_limit_s=0.2, limit_iterations=10_000
+            retrosynthesis_task2,
+            time_limit_s=0.2 * self.time_limit_multiplier,
+            limit_iterations=10_000,
         )
         assert len(route_objs) > 5  # should find AT LEAST this many routes
 
@@ -519,7 +525,7 @@ class BaseAlgorithmTest(abc.ABC):
 
         route_objs = self._run_alg_and_extract_routes(
             retrosynthesis_task1,
-            time_limit_s=0.1,
+            time_limit_s=0.1 * self.time_limit_multiplier,
             limit_iterations=10_000,
             stop_on_first_solution=True,
         )


### PR DESCRIPTION
Many algorithm tests involve running the algorithms for a fixed number of iterations or maximum time limit, then checking that a certain outcome happened. However, algorithms with a slow iteration speed may not achieve the desired outcome within the time limit if their iteration time is slow. I found an example of this when writing an algorithm that does a lot of computation with numpy arrays.

If we want slower algorithms to be testable by extending the `BaseAlgorithmTest`, I saw two options:

1. Extend the tolerances of all tests in the base class. This would have the side effect of making the tests for all algorithms take longer (e.g. 5s -> 30s)
2. Add a "time multiplier" which defaults to a small value, but can be overridden by child classes that want more time.

I decided that option 2 makes more sense, so this PR implements it. Specifically, I added an attribute `time_limit_multiplier` to `BaseAlgorithmTest`, and replaced all instances of `time_limit_s=X` with `time_limit_s=X*self.time_limit_multiplier` (except in the test for time limits themselves because there an absolute tolerance is tested). This can be overridden in child classes.