### PR TITLE
Handle the empty input case in ReactionModelBasedEvaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Add a top-level CLI for running end-to-end search ([#26](https://github.com/microsoft/syntheseus/pull/26)) ([@kmaziarz])
 - Release single-step evaluation framework and wrappers for several model types ([#14](https://github.com/microsoft/syntheseus/pull/14), [#15](https://github.com/microsoft/syntheseus/pull/15), [#20](https://github.com/microsoft/syntheseus/pull/20)) ([@kmaziarz])
 - Release checkpoints for all supported single-step model types ([#21](https://github.com/microsoft/syntheseus/pull/21)) ([@kmaziarz])
-- Implement node evaluators commonly used in MCTS and Retro* ([#23](https://github.com/microsoft/syntheseus/pull/23)) ([@kmaziarz])
+- Implement node evaluators commonly used in MCTS and Retro* ([#23](https://github.com/microsoft/syntheseus/pull/23), [#27](https://github.com/microsoft/syntheseus/pull/27)) ([@kmaziarz])
 - Add option to terminate search when the first solution is found ([#13](https://github.com/microsoft/syntheseus/pull/13)) ([@austint])
 - Add code to extract routes in order found instead of by minimum cost ([#9](https://github.com/microsoft/syntheseus/pull/9)) ([@austint])
 - Declare support for type checking ([#4](https://github.com/microsoft/syntheseus/pull/4)) ([@kmaziarz])

--- a/syntheseus/search/node_evaluation/base.py
+++ b/syntheseus/search/node_evaluation/base.py
@@ -75,6 +75,9 @@ class NoCacheNodeEvaluator(BaseNodeEvaluator[NodeType]):
     def __call__(
         self, nodes: Sequence[NodeType], graph: Optional[RetrosynthesisSearchGraph] = None
     ) -> Sequence[float]:
+        if not nodes:  # handle the case when there are no nodes to score
+            return []
+
         self._num_calls += len(nodes)
         return self._evaluate_nodes(nodes, graph)
 
@@ -138,9 +141,6 @@ class ReactionModelBasedEvaluator(NoCacheNodeEvaluator[NodeType]):
         return metadata["probability"]  # type: ignore
 
     def _evaluate_nodes(self, nodes, graph=None) -> Sequence[float]:
-        if not nodes:  # handle the case when there are no nodes to score
-            return []
-
         probs = np.asarray([self._get_probability(n, graph) for n in nodes])
         probs = np.clip(probs, a_min=self._clip_probability_min, a_max=self._clip_probability_max)
 

--- a/syntheseus/search/node_evaluation/base.py
+++ b/syntheseus/search/node_evaluation/base.py
@@ -138,6 +138,9 @@ class ReactionModelBasedEvaluator(NoCacheNodeEvaluator[NodeType]):
         return metadata["probability"]  # type: ignore
 
     def _evaluate_nodes(self, nodes, graph=None) -> Sequence[float]:
+        if not nodes:  # handle the case when there are no nodes to score
+            return []
+
         probs = np.asarray([self._get_probability(n, graph) for n in nodes])
         probs = np.clip(probs, a_min=self._clip_probability_min, a_max=self._clip_probability_max)
 


### PR DESCRIPTION
Node evaluators based on `ReactionModelBasedEvaluator` can perform normalization; if done in log space, this can fail if the input list is empty (due to taking `max` of an empty array). Whether empty lists are actually passed in for evaluation depends on the exact algorithm (it does not seem to happen in MCTS, but does happen in Retro*), so it's best to guard against that in the evaluator itself as done in this PR.