### PR TITLE
Speed up the diversity estimation heuristic

### DIFF
--- a/syntheseus/search/analysis/diversity.py
+++ b/syntheseus/search/analysis/diversity.py
@@ -76,6 +76,8 @@ def estimate_packing_number(
 
         # Construct a packing set and check whether it is better than the previous one
         packing_set = _recursive_construct_packing_set(
+            0,
+            len(route_list),
             route_list,
             radius,
             distance_metric,
@@ -94,6 +96,8 @@ def estimate_packing_number(
 
 
 def _recursive_construct_packing_set(
+    idx_start: int,
+    idx_end: int,
     routes: list[SynthesisGraph],
     radius: float,
     distance_metric: ROUTE_DISTANCE_METRIC,
@@ -131,15 +135,17 @@ def _recursive_construct_packing_set(
     ), "Max packing number must be positive."
 
     # Base cases:
-    if len(routes) <= 1:
-        return list(routes)
+    if idx_end - idx_start <= 1:
+        return routes[idx_start:idx_end]
 
     # Recursive case:
     # First calculate packing set for both halves
-    cutoff_idx = len(routes) // 2
+    cutoff_idx = (idx_start + idx_end) // 2
 
     route_set1 = _recursive_construct_packing_set(
-        routes[:cutoff_idx],
+        idx_start,
+        cutoff_idx,
+        routes,
         radius,
         distance_metric,
         max_packing_number,
@@ -148,7 +154,9 @@ def _recursive_construct_packing_set(
         return route_set1
 
     route_set2 = _recursive_construct_packing_set(
-        routes[cutoff_idx:],
+        cutoff_idx,
+        idx_end,
+        routes,
         radius,
         distance_metric,
         max_packing_number,

--- a/syntheseus/search/analysis/diversity.py
+++ b/syntheseus/search/analysis/diversity.py
@@ -197,12 +197,13 @@ def _jaccard_distance(
     set1: set,
     set2: set,
 ) -> float:
-    intersection = set1 & set2
-    union = set1 | set2
-    if len(union) == 0:
+    intersection_size = len(set1 & set2)
+    union_size = len(set1) + len(set2) - intersection_size
+
+    if union_size == 0:
         return 0.0  # both sets are empty so distance is 0
     else:
-        return 1.0 - len(intersection) / len(union)
+        return 1.0 - intersection_size / union_size
 
 
 def _get_reactions(route: SynthesisGraph) -> set[BackwardReaction]:

--- a/syntheseus/search/analysis/diversity.py
+++ b/syntheseus/search/analysis/diversity.py
@@ -134,9 +134,16 @@ def _recursive_construct_packing_set(
         max_packing_number is None or max_packing_number > 0
     ), "Max packing number must be positive."
 
-    # Base cases:
-    if idx_end - idx_start <= 1:
-        return routes[idx_start:idx_end]
+    # Base cases: simple greedy algorithm is optimal if there are no more than two routes
+    if idx_end - idx_start <= 2:
+        best_set = []
+        for idx in range(idx_start, idx_end):
+            if all(distance_metric(routes[idx], route) > radius for route in best_set):
+                best_set.append(routes[idx])
+                if len(best_set) == max_packing_number:
+                    break
+
+        return best_set
 
     # Recursive case:
     # First calculate packing set for both halves


### PR DESCRIPTION
This PR applies three small tweaks to the diverse subset extraction heuristic, speeding it up without changing semantics:
- The recursive calls of `_recursive_construct_packing_set` all make use of the same (unchanging) list of routes, just consider different slices of that list. Instead of slicing the input list repeatedly in each recursive call (which does a lot of copying), it is more efficient to just pass in indices pointing to the slice under consideration (this changes the signature of the private `_recursive_construct_packing_set`, but the signature of the public `estimate_packing_number` remains unchanged).
- The `_jaccard_distance` function was instantiating both a set intersection and a set union of its arguments, whereas intersection size alone is enough to compute the distance.
- With `n <= 1` as a base case, `_recursive_construct_packing_set` was spending a lot of time on finding diverse subsets for inputs with tiny `n` e.g. `n = 2`, as there is overhead in e.g. creating tiny graphs. It is more efficient to make `n = 2` one of the base cases, as it's trivial to solve it optimally.

Empirically, these changes speed up the algorithm by 3%, 3% and 22%, respectively (together compounding to a speedup of around 26%).