### PR TITLE
Set model-specific hyperparameter defaults for search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Select search hyperparameters depending on which algorithm and single-step model are used ([#30](https://github.com/microsoft/syntheseus/pull/30)) ([@kmaziarz])
 - Add option to override time tolerance in algorithm tests ([#25](https://github.com/microsoft/syntheseus/pull/25)) ([@austint])
 - Improve the heuristic used for estimating diversity ([#22](https://github.com/microsoft/syntheseus/pull/22), [#28](https://github.com/microsoft/syntheseus/pull/28)) ([@kmaziarz])
 - Improve the aesthetics of `README.md` ([#19](https://github.com/microsoft/syntheseus/pull/19)) ([@kmaziarz])

--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -112,7 +112,7 @@ class SearchConfig(BackwardModelConfig):
     num_routes_to_plot: int = 5  # Number of routes to extract and plot for a quick check
 
 
-def run_from_config(config: SearchConfig) -> None:
+def run_from_config(config: SearchConfig) -> Path:
     set_random_seed(0)
 
     print("Running search with the following config:")
@@ -305,8 +305,10 @@ def run_from_config(config: SearchConfig) -> None:
         with open(results_dir_current_run / "stats.json", "wt") as f_combined_stats:
             f_combined_stats.write(json.dumps(combined_stats, indent=2))
 
+    return results_dir_current_run
 
-def main(argv: Optional[List[str]]) -> None:
+
+def main(argv: Optional[List[str]]) -> Path:
     config: SearchConfig = cli_get_config(argv=argv, config_cls=SearchConfig)
 
     def _warn_will_not_use_defaults(message: str) -> None:
@@ -345,7 +347,7 @@ def main(argv: Optional[List[str]]) -> None:
                     defaults={f"{config.search_algorithm}_config": relevant_defaults},
                 )
 
-    run_from_config(config)
+    return run_from_config(config)
 
 
 if __name__ == "__main__":

--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from pprint import pformat
 from typing import Any, Dict, Iterator, List, Optional, cast
 
+import yaml
 from omegaconf import MISSING, DictConfig, OmegaConf
 from tqdm import tqdm
 
@@ -73,7 +74,7 @@ class MCTSConfig:
     policy_class: str = "ReactionModelProbPolicy"
     policy_kwargs: Dict[str, Any] = field(default_factory=dict)
 
-    bound_constant: float = 1e2
+    bound_constant: float = 1.0
     bound_function_class: str = "pucb_bound"
 
 
@@ -307,6 +308,43 @@ def run_from_config(config: SearchConfig) -> None:
 
 def main(argv: Optional[List[str]]) -> None:
     config: SearchConfig = cli_get_config(argv=argv, config_cls=SearchConfig)
+
+    def _warn_will_not_use_defaults(message: str) -> None:
+        logger.warning(f"{message}; no model-specific search hyperparameters will be used")
+
+    defaults_file_path = Path(__file__).parent / "search_config.yml"
+    if not defaults_file_path.exists():
+        _warn_will_not_use_defaults(f"File {defaults_file_path} does not exist")
+    else:
+        with open(defaults_file_path, "rt") as f_defaults:
+            defaults = yaml.safe_load(f_defaults)
+
+        if config.search_algorithm not in defaults:
+            _warn_will_not_use_defaults(
+                f"Hyperparameter defaults file has no entry for {config.search_algorithm}"
+            )
+        else:
+            search_algorithm_defaults = defaults[config.search_algorithm]
+
+            model_name = config.model_class.name
+            if model_name not in search_algorithm_defaults:
+                _warn_will_not_use_defaults(
+                    f"Hyperparameter defaults file has no entry for {model_name}"
+                )
+            else:
+                relevant_defaults = search_algorithm_defaults[model_name]
+                logger.info(
+                    f"Using hyperparameter defaults from {defaults_file_path}: {relevant_defaults}"
+                )
+
+                # We now parse the config again (we could not have included the defaults earlier as
+                # we did not know the search algorithm and model class before the first parsing).
+                config = cli_get_config(
+                    argv=argv,
+                    config_cls=SearchConfig,
+                    defaults={f"{config.search_algorithm}_config": relevant_defaults},
+                )
+
     run_from_config(config)
 
 

--- a/syntheseus/cli/search_config.yml
+++ b/syntheseus/cli/search_config.yml
@@ -2,24 +2,18 @@ mcts:
   Chemformer:
     bound_constant: 1
     policy_kwargs:
-      clip_probability_max: 0.9
-      clip_probability_min: 1.0e-06
       temperature: 8.0
     value_function_kwargs:
       constant: 0.75
   GLN:
     bound_constant: 100
     policy_kwargs:
-      clip_probability_max: 0.9
-      clip_probability_min: 1.0e-07
       temperature: 4.0
     value_function_kwargs:
       constant: 0.5
   LocalRetro:
     bound_constant: 1
     policy_kwargs:
-      clip_probability_max: 0.9
-      clip_probability_min: 1.0e-05
       temperature: 4.0
     value_function_kwargs:
       constant: 0.5
@@ -34,16 +28,12 @@ mcts:
   MHNreact:
     bound_constant: 1
     policy_kwargs:
-      clip_probability_max: 0.9
-      clip_probability_min: 1.0e-11
       temperature: 8.0
     value_function_kwargs:
       constant: 0.5
   RetroKNN:
     bound_constant: 1
     policy_kwargs:
-      clip_probability_max: 0.9
-      clip_probability_min: 1.0e-07
       temperature: 8.0
     value_function_kwargs:
       constant: 0.75
@@ -56,30 +46,10 @@ mcts:
     value_function_kwargs:
       constant: 0.5
 retro_star:
-  Chemformer:
-    and_node_cost_fn_kwargs:
-      clip_probability_max: 0.999
-      clip_probability_min: 1.0e-09
-  GLN:
-    and_node_cost_fn_kwargs:
-      clip_probability_max: 0.99
-      clip_probability_min: 1.0e-05
-  LocalRetro:
-    and_node_cost_fn_kwargs:
-      clip_probability_max: 0.999
-      clip_probability_min: 1.0e-05
   MEGAN:
     and_node_cost_fn_kwargs:
       clip_probability_max: 0.99
       clip_probability_min: 1.0e-05
-  MHNreact:
-    and_node_cost_fn_kwargs:
-      clip_probability_max: 0.9999
-      clip_probability_min: 1.0e-08
-  RetroKNN:
-    and_node_cost_fn_kwargs:
-      clip_probability_max: 0.999
-      clip_probability_min: 1.0e-11
   RootAligned:
     and_node_cost_fn_kwargs:
       clip_probability_max: 0.9999

--- a/syntheseus/cli/search_config.yml
+++ b/syntheseus/cli/search_config.yml
@@ -1,0 +1,86 @@
+mcts:
+  Chemformer:
+    bound_constant: 1
+    policy_kwargs:
+      clip_probability_max: 0.9
+      clip_probability_min: 1.0e-06
+      temperature: 8.0
+    value_function_kwargs:
+      constant: 0.75
+  GLN:
+    bound_constant: 100
+    policy_kwargs:
+      clip_probability_max: 0.9
+      clip_probability_min: 1.0e-07
+      temperature: 4.0
+    value_function_kwargs:
+      constant: 0.5
+  LocalRetro:
+    bound_constant: 1
+    policy_kwargs:
+      clip_probability_max: 0.9
+      clip_probability_min: 1.0e-05
+      temperature: 4.0
+    value_function_kwargs:
+      constant: 0.5
+  MEGAN:
+    bound_constant: 1
+    policy_kwargs:
+      clip_probability_max: 0.9999
+      clip_probability_min: 1.0e-05
+      temperature: 2.0
+    value_function_kwargs:
+      constant: 0.75
+  MHNreact:
+    bound_constant: 1
+    policy_kwargs:
+      clip_probability_max: 0.9
+      clip_probability_min: 1.0e-11
+      temperature: 8.0
+    value_function_kwargs:
+      constant: 0.5
+  RetroKNN:
+    bound_constant: 1
+    policy_kwargs:
+      clip_probability_max: 0.9
+      clip_probability_min: 1.0e-07
+      temperature: 8.0
+    value_function_kwargs:
+      constant: 0.75
+  RootAligned:
+    bound_constant: 10
+    policy_kwargs:
+      clip_probability_max: 0.999
+      clip_probability_min: 1.0e-05
+      temperature: 8.0
+    value_function_kwargs:
+      constant: 0.5
+retro_star:
+  Chemformer:
+    and_node_cost_fn_kwargs:
+      clip_probability_max: 0.999
+      clip_probability_min: 1.0e-09
+  GLN:
+    and_node_cost_fn_kwargs:
+      clip_probability_max: 0.99
+      clip_probability_min: 1.0e-05
+  LocalRetro:
+    and_node_cost_fn_kwargs:
+      clip_probability_max: 0.999
+      clip_probability_min: 1.0e-05
+  MEGAN:
+    and_node_cost_fn_kwargs:
+      clip_probability_max: 0.99
+      clip_probability_min: 1.0e-05
+  MHNreact:
+    and_node_cost_fn_kwargs:
+      clip_probability_max: 0.9999
+      clip_probability_min: 1.0e-08
+  RetroKNN:
+    and_node_cost_fn_kwargs:
+      clip_probability_max: 0.999
+      clip_probability_min: 1.0e-11
+  RootAligned:
+    and_node_cost_fn_kwargs:
+      clip_probability_max: 0.9999
+      clip_probability_min: 1.0e-08

--- a/syntheseus/reaction_prediction/utils/config.py
+++ b/syntheseus/reaction_prediction/utils/config.py
@@ -1,13 +1,17 @@
 import argparse
 import sys
-from typing import Callable, List, Optional, TypeVar, cast
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, cast
 
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, ListConfig, OmegaConf
 
 R = TypeVar("R")
 
 
-def get_config(argv: Optional[List[str]], config_cls: Callable[..., R]) -> R:
+def get_config(
+    argv: Optional[List[str]],
+    config_cls: Callable[..., R],
+    defaults: Optional[Dict[str, Any]] = None,
+) -> R:
     """
     Utility function to get `OmegaConf` config options.
 
@@ -37,8 +41,12 @@ def get_config(argv: Optional[List[str]], config_cls: Callable[..., R]) -> R:
     )
     args, config_changes = parser.parse_known_args(argv)
 
-    # Read configs from file and command line
-    conf_yamls = [OmegaConf.load(c) for c in args.config]
+    # Read configs from defaults, file and command line
+    conf_yamls: List[Union[DictConfig, ListConfig]] = []
+    if defaults:
+        conf_yamls = [OmegaConf.create(defaults)]
+
+    conf_yamls += [OmegaConf.load(c) for c in args.config]
     conf_cli = OmegaConf.from_cli(config_changes)
 
     # Make merged config options


### PR DESCRIPTION
Following hyperparameter tuning on 25 targets from the ChemBL Hard set (as used in "Re-Evaluating Chemical Synthesis Planning Algorithms"), this PR places the best settings found in `cli/search_config.yml`, and makes `search.py` pick up the defaults from the file if one happens to be using a supported model/algorithm combination.