### PR TITLE
Guard against rare issues in LocalRetro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix bug where standardizing MolSetGraphs crashed ([#24](https://github.com/microsoft/syntheseus/pull/24)) ([@austint])
+- Guard against rare issues in LocalRetro ([#31](https://github.com/microsoft/syntheseus/pull/31)) ([@kmaziarz])
 - Change default node depth to infinity ([#16](https://github.com/microsoft/syntheseus/pull/16)) ([@austint])
 - Adapt tutorials to the renaming from PR #9 ([#17](https://github.com/microsoft/syntheseus/pull/17)) ([@jagarridotorres])
 - Fix error handling in MEGAN ([#29](https://github.com/microsoft/syntheseus/pull/29)) ([@kmaziarz])

--- a/syntheseus/reaction_prediction/inference/local_retro.py
+++ b/syntheseus/reaction_prediction/inference/local_retro.py
@@ -83,8 +83,8 @@ class LocalRetroModel(BackwardReactionModel):
         return collate_molgraphs_test([(None, graph, None) for graph in graphs])[1]
 
     def _build_batch_predictions(
-        self, batch, num_results, inputs, batch_atom_logits, batch_bond_logits
-    ):
+        self, batch, num_results: int, inputs: List[Molecule], batch_atom_logits, batch_bond_logits
+    ) -> List[BackwardPredictionList]:
         from local_retro.scripts.Decode_predictions import get_k_predictions
         from local_retro.scripts.get_edit import combined_edit, get_bg_partition
 

--- a/syntheseus/reaction_prediction/inference/local_retro.py
+++ b/syntheseus/reaction_prediction/inference/local_retro.py
@@ -113,10 +113,16 @@ class LocalRetroModel(BackwardReactionModel):
 
         batch_predictions = []
         for idx, input in enumerate(inputs):
+            try:
+                raw_str_results = get_k_predictions(test_id=idx, args=self.args)[1][0]
+            except RuntimeError:
+                # In very rare cases we may get `rdkit` errors.
+                raw_str_results = []
+
             # We have to `eval` the predictions as they come rendered into strings. Second tuple
             # component is empirically (on USPTO-50K test set) in [0, 1], resembling a probability,
             # but does not sum up to 1.0 (usually to something in [0.5, 2.0]).
-            raw_results = list(map(eval, get_k_predictions(test_id=idx, args=self.args)[1][0]))
+            raw_results = [eval(str_result) for str_result in raw_str_results]
 
             if raw_results:
                 raw_outputs, probabilities = zip(*raw_results)


### PR DESCRIPTION
In very rare cases LocalRetro's `get_k_predictions` can fail with `RuntimeError` originating from `rdkit`. I have not seen this with the USPTO-trained checkpoint, but it did happen once when evaluating a Pistachio-trained checkpoint (which has a much larger template diversity). This PR guards against this by simply falling back to returning no results if an error is raised.