### PR TITLE
Update the LocalRetro checkout to a newer commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Implement node evaluators commonly used in MCTS and Retro* ([#23](https://github.com/microsoft/syntheseus/pull/23), [#27](https://github.com/microsoft/syntheseus/pull/27)) ([@kmaziarz])
 - Add option to terminate search when the first solution is found ([#13](https://github.com/microsoft/syntheseus/pull/13)) ([@austint])
 - Add code to extract routes in order found instead of by minimum cost ([#9](https://github.com/microsoft/syntheseus/pull/9)) ([@austint])
+- Update the LocalRetro checkout to a newer commit ([#32](https://github.com/microsoft/syntheseus/pull/32)) ([@kmaziarz])
 - Declare support for type checking ([#4](https://github.com/microsoft/syntheseus/pull/4)) ([@kmaziarz])
 
 ### Fixed

--- a/syntheseus/reaction_prediction/environments/setup_local_retro.sh
+++ b/syntheseus/reaction_prediction/environments/setup_local_retro.sh
@@ -7,6 +7,6 @@ pip install dgllife chardet
 export GITHUB_ORG_NAME=kaist-amsg
 export GITHUB_REPO_NAME=LocalRetro
 export GITHUB_REPO_DIR=local_retro
-export GITHUB_COMMIT_ID=7dab59f7f85eca8b1c04c18fe8575fb1568ff7ae
+export GITHUB_COMMIT_ID=28aa215236c20e719fa4c977089c62fef551adf2
 
 source setup_shared.sh


### PR DESCRIPTION
This PR updates the checkout of the external LocalRetro repository to pull in recent changes that happened upstream. This mostly enables training on larger datasets, but also brings a bit of improvement in dependency version flexibility and architecture customization.

Out of the box these new changes are not compatible with RetroKNN, which in one place depends on the bond order used by the underlying code, and that order has recently been changed. Concretely, RetroKNN contains code to convert the old bond order used by LocalRetro to a different one. As the latter coincides with the new order, this part of code can just be deleted.