### PR TITLE
Support *.csv and *.smi formats for the single-step evaluation data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Add a top-level CLI for running end-to-end search ([#26](https://github.com/microsoft/syntheseus/pull/26)) ([@kmaziarz])
 - Release single-step evaluation framework and wrappers for several model types ([#14](https://github.com/microsoft/syntheseus/pull/14), [#15](https://github.com/microsoft/syntheseus/pull/15), [#20](https://github.com/microsoft/syntheseus/pull/20)) ([@kmaziarz])
 - Release checkpoints for all supported single-step model types ([#21](https://github.com/microsoft/syntheseus/pull/21)) ([@kmaziarz])
+- Support `*.csv` and `*.smi` formats for the single-step evaluation data ([#33](https://github.com/microsoft/syntheseus/pull/33)) ([@kmaziarz])
 - Implement node evaluators commonly used in MCTS and Retro* ([#23](https://github.com/microsoft/syntheseus/pull/23), [#27](https://github.com/microsoft/syntheseus/pull/27)) ([@kmaziarz])
 - Add option to terminate search when the first solution is found ([#13](https://github.com/microsoft/syntheseus/pull/13)) ([@austint])
 - Add code to extract routes in order found instead of by minimum cost ([#9](https://github.com/microsoft/syntheseus/pull/9)) ([@austint])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,22 +17,20 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Added
 - Add code for PDVN MCTS and extracting training data for policies and value functions ([#8](https://github.com/microsoft/syntheseus/pull/8)) ([@austint], [@fiberleif])
 - Add a top-level CLI for running end-to-end search ([#26](https://github.com/microsoft/syntheseus/pull/26)) ([@kmaziarz])
-- Release single-step evaluation framework and wrappers for several model types ([#14](https://github.com/microsoft/syntheseus/pull/14), [#15](https://github.com/microsoft/syntheseus/pull/15), [#20](https://github.com/microsoft/syntheseus/pull/20)) ([@kmaziarz])
+- Release single-step evaluation framework and wrappers for several model types ([#14](https://github.com/microsoft/syntheseus/pull/14), [#15](https://github.com/microsoft/syntheseus/pull/15), [#20](https://github.com/microsoft/syntheseus/pull/20), [#32](https://github.com/microsoft/syntheseus/pull/32)) ([@kmaziarz])
 - Release checkpoints for all supported single-step model types ([#21](https://github.com/microsoft/syntheseus/pull/21)) ([@kmaziarz])
 - Support `*.csv` and `*.smi` formats for the single-step evaluation data ([#33](https://github.com/microsoft/syntheseus/pull/33)) ([@kmaziarz])
 - Implement node evaluators commonly used in MCTS and Retro* ([#23](https://github.com/microsoft/syntheseus/pull/23), [#27](https://github.com/microsoft/syntheseus/pull/27)) ([@kmaziarz])
 - Add option to terminate search when the first solution is found ([#13](https://github.com/microsoft/syntheseus/pull/13)) ([@austint])
 - Add code to extract routes in order found instead of by minimum cost ([#9](https://github.com/microsoft/syntheseus/pull/9)) ([@austint])
-- Update the LocalRetro checkout to a newer commit ([#32](https://github.com/microsoft/syntheseus/pull/32)) ([@kmaziarz])
 - Declare support for type checking ([#4](https://github.com/microsoft/syntheseus/pull/4)) ([@kmaziarz])
 
 ### Fixed
 
 - Fix bug where standardizing MolSetGraphs crashed ([#24](https://github.com/microsoft/syntheseus/pull/24)) ([@austint])
-- Guard against rare issues in LocalRetro ([#31](https://github.com/microsoft/syntheseus/pull/31)) ([@kmaziarz])
+- Guard against rare issues in MEGAN and LocalRetro ([#29](https://github.com/microsoft/syntheseus/pull/29), [#31](https://github.com/microsoft/syntheseus/pull/31)) ([@kmaziarz])
 - Change default node depth to infinity ([#16](https://github.com/microsoft/syntheseus/pull/16)) ([@austint])
 - Adapt tutorials to the renaming from PR #9 ([#17](https://github.com/microsoft/syntheseus/pull/17)) ([@jagarridotorres])
-- Fix error handling in MEGAN ([#29](https://github.com/microsoft/syntheseus/pull/29)) ([@kmaziarz])
 - Pin `pydantic` version to `1.*` ([#10](https://github.com/microsoft/syntheseus/pull/10)) ([@kmaziarz])
 - Fix compatibility with Python 3.7 ([#5](https://github.com/microsoft/syntheseus/pull/5)) ([@kmaziarz])
 - Pin `zipp` version to `<3.16` ([#11](https://github.com/microsoft/syntheseus/pull/11)) ([@kmaziarz])

--- a/syntheseus/reaction_prediction/cli/eval.md
+++ b/syntheseus/reaction_prediction/cli/eval.md
@@ -1,0 +1,51 @@
+# Single-step Evaluation
+
+## Usage
+
+To run single-step model evaluation, run
+
+```
+python ./retrosynthesis/reaction_prediction/cli/eval.py \
+    data_dir=[DATA_DIR] \
+    model_class=[MODEL_CLASS] \
+    model_dir=[MODEL_DIR]
+```
+
+The script accepts further arguments to customize the evaluation such as which data fold to use; see `BaseEvalConfig` for the complete list.
+
+The code will scan `data_dir` looking for files matching `*{train, val, test}.{jsonl, csv, smi}` and select the right data format based on the file extension. An error will be raised in case of ambiguity. Only the fold that was selected for evaluation has to be present.
+
+## Data format
+
+The single-step evaluation script supports reaction data in one of three formats.
+
+### JSONL
+
+Our internal format based on `*.jsonl` files in which each line is a JSON representation of a single reaction, for example:
+```json
+{"reactants": [{"smiles": "Cc1ccc(Br)cc1"}, {"smiles": "Cc1ccc(B(O)O)cc1"}], "products": [{"smiles": "Cc1ccc(-c2ccc(C)cc2)cc1"}]}
+```
+This format is designed to be flexible at the expense of taking more disk space. The JSON is parsed into a `ReactionSample` object, so it can include additional metadata such as template information, while the reactants and products can include other fields accepted by the `Molecule` object. The evaluation script will only use reactant and product SMILES to compute the metrics.
+
+Unlike the other formats below, reactants and products in this format are assumed to be already stripped of atom mapping, which leads to slightly faster data loading as that avoids extra calls to `rdkit`.
+
+### CSV
+
+This format is based on `*.csv` files and is commonly used to store raw USPTO data, e.g. as released by [Dai et al.](https://github.com/Hanjun-Dai/GLN):
+
+```
+id,class,reactants>reagents>production
+ID,UNK,[cH:1]1[cH:2][c:3]([CH3:4])[cH:5][cH:6][c:7]1Br.B(O)(O)[c:8]1[cH:9][cH:10][c:11]([CH3:12])[cH:13][cH:14]1>>[cH:1]1[cH:2][c:3]([CH3:4])[cH:5][cH:6][c:7]1[c:8]2[cH:14][cH:13][c:11]([CH3:12])[cH:10][cH:9]2
+```
+
+The evaluation script will look for the `reactants>reagents>production` column to extract the reaction SMILES, which are stripped of atom mapping and canonicalized before being fed to the model.
+
+### SMILES
+
+The most compact format is to list reaction SMILES line-by-line in a `*.smi` file:
+
+```
+[cH:1]1[cH:2][c:3]([CH3:4])[cH:5][cH:6][c:7]1Br.B(O)(O)[c:8]1[cH:9][cH:10][c:11]([CH3:12])[cH:13][cH:14]1>>[cH:1]1[cH:2][c:3]([CH3:4])[cH:5][cH:6][c:7]1[c:8]2[cH:14][cH:13][c:11]([CH3:12])[cH:10][cH:9]2
+```
+
+The data will be handled in the same way as for the CSV format, i.e. it will only be fed into model after removing atom mapping and canonicalization.

--- a/syntheseus/reaction_prediction/data/dataset.py
+++ b/syntheseus/reaction_prediction/data/dataset.py
@@ -1,22 +1,37 @@
+from __future__ import annotations
+
+import csv
 import json
+import logging
 from abc import abstractmethod
 from enum import Enum
 from functools import partial
 from pathlib import Path
-from typing import Dict, Generic, Iterable, Type, TypeVar, Union
+from typing import Dict, Generic, Iterable, List, Optional, Type, TypeVar, Union
 
 from more_itertools import ilen
 
 from syntheseus.reaction_prediction.data.reaction_sample import ReactionSample
 from syntheseus.reaction_prediction.utils.misc import asdict_extended, parallelize
 
+logger = logging.getLogger(__file__)
+
 SampleType = TypeVar("SampleType", bound=ReactionSample)
+
+
+CSV_REACTION_SMILES_COLUMN_NAME = "reactants>reagents>production"
 
 
 class DataFold(Enum):
     TRAIN = "train"
     VALIDATION = "val"
     TEST = "test"
+
+
+class DataFormat(Enum):
+    JSONL = "jsonl"
+    CSV = "csv"
+    SMILES = "smi"
 
 
 class ReactionDataset(Generic[SampleType]):
@@ -37,28 +52,71 @@ class DiskReactionDataset(ReactionDataset[SampleType]):
         data_dir: Union[str, Path],
         sample_cls: Type[SampleType],
         num_processes: int = 0,
+        data_format: Optional[DataFormat] = None,
     ):
-        self._data_dir = data_dir
+        self._data_dir = Path(data_dir)
         self._sample_cls = sample_cls
         self._num_processes = num_processes
 
+        filenames = [str(filename) for filename in self._data_dir.iterdir()]
+
+        if data_format is None:
+            logger.info(f"Detecting data format from files: {filenames}")
+            formats_to_try = list(DataFormat)
+        else:
+            formats_to_try = [data_format]
+
+        matches = {
+            format: DiskReactionDataset.match_filenames_to_folds(format=format, filenames=filenames)
+            for format in formats_to_try
+        }
+        matches = {key: values for key, values in matches.items() if values}
+
+        if data_format is None:
+            if len(matches) != 1:
+                raise ValueError(
+                    f"Format detection failed (formats matching the file list: {[f.name for f in matches]})"
+                )
+        elif not matches:
+            raise ValueError(
+                f"No files matching *{{train, val, test}}.{data_format.value} were found"
+            )
+
+        [(self._data_format, fold_to_filename)] = matches.items()
+
+        if data_format is None:
+            logger.info(f"Detected format: {self._data_format.name}")
+
+        logger.info(f"Loading data from files {fold_to_filename}")
+
+        self._fold_to_path = {
+            fold: self._data_dir / filename for fold, filename in fold_to_filename.items()
+        }
         self._num_samples: Dict[DataFold, int] = {}
 
     def _get_lines(self, fold: DataFold) -> Iterable[str]:
-        data_path = DiskReactionDataset.get_data_path(data_dir=self._data_dir, fold=fold)
-
-        if not data_path.exists():
+        if fold not in self._fold_to_path:
             return []
         else:
-            with open(data_path) as f:
-                yield from f
+            with open(self._fold_to_path[fold]) as f:
+                if self._data_format == DataFormat.CSV:
+                    for row in csv.DictReader(f):
+                        if CSV_REACTION_SMILES_COLUMN_NAME not in row:
+                            raise ValueError(
+                                f"No {CSV_REACTION_SMILES_COLUMN_NAME} column found in the CSV data file"
+                            )
+                        yield row[CSV_REACTION_SMILES_COLUMN_NAME]
+                else:
+                    for line in f:
+                        yield line.rstrip()
 
     def __getitem__(self, fold: DataFold) -> Iterable[SampleType]:
-        yield from parallelize(
-            partial(DiskReactionDataset.sample_from_json, sample_cls=self._sample_cls),
-            self._get_lines(fold),
-            num_processes=self._num_processes,
-        )
+        if self._data_format == DataFormat.JSONL:
+            parse_fn = partial(DiskReactionDataset.sample_from_json, sample_cls=self._sample_cls)
+        else:
+            parse_fn = partial(self._sample_cls.from_reaction_smiles_strict, mapped=True)
+
+        yield from parallelize(parse_fn, self._get_lines(fold), num_processes=self._num_processes)
 
     def get_num_samples(self, fold: DataFold) -> int:
         if fold not in self._num_samples:
@@ -67,8 +125,26 @@ class DiskReactionDataset(ReactionDataset[SampleType]):
         return self._num_samples[fold]
 
     @staticmethod
-    def get_data_path(data_dir: Union[str, Path], fold: DataFold) -> Path:
-        return Path(data_dir) / f"{fold.value}.jsonl"
+    def match_filenames_to_folds(format: DataFormat, filenames: List[str]) -> Dict[DataFold, str]:
+        fold_to_filename: Dict[DataFold, str] = {}
+        for fold in DataFold:
+            suffix = DiskReactionDataset.get_filename_suffix(format, fold)
+            matching_filenames = [filename for filename in filenames if filename.endswith(suffix)]
+
+            if len(matching_filenames) > 1:
+                raise ValueError(
+                    f"Found more than one {format.value} file for fold {fold.name}: {matching_filenames}"
+                )
+
+            if matching_filenames:
+                [filename] = matching_filenames
+                fold_to_filename[fold] = filename
+
+        return fold_to_filename
+
+    @staticmethod
+    def get_filename_suffix(format: DataFormat, fold: DataFold) -> str:
+        return f"{fold.value}.{format.value}"
 
     @staticmethod
     def sample_from_json(data: str, sample_cls: Type[SampleType]) -> SampleType:
@@ -78,6 +154,8 @@ class DiskReactionDataset(ReactionDataset[SampleType]):
     def save_samples_to_file(
         data_dir: Union[str, Path], fold: DataFold, samples: Iterable[SampleType]
     ) -> None:
-        with open(DiskReactionDataset.get_data_path(data_dir=data_dir, fold=fold), "wt") as f:
+        filename = DiskReactionDataset.get_filename_suffix(format=DataFormat.JSONL, fold=fold)
+
+        with open(Path(data_dir) / filename, "wt") as f:
             for sample in samples:
                 f.write(json.dumps(asdict_extended(sample)) + "\n")

--- a/syntheseus/reaction_prediction/data/dataset.py
+++ b/syntheseus/reaction_prediction/data/dataset.py
@@ -66,17 +66,17 @@ class DiskReactionDataset(ReactionDataset[SampleType]):
 
         return self._num_samples[fold]
 
-    @classmethod
-    def get_data_path(cls, data_dir: Union[str, Path], fold: DataFold) -> Path:
+    @staticmethod
+    def get_data_path(data_dir: Union[str, Path], fold: DataFold) -> Path:
         return Path(data_dir) / f"{fold.value}.jsonl"
 
-    @classmethod
-    def sample_from_json(cls, data: str, sample_cls: Type[SampleType]) -> SampleType:
+    @staticmethod
+    def sample_from_json(data: str, sample_cls: Type[SampleType]) -> SampleType:
         return sample_cls.from_dict(json.loads(data))
 
-    @classmethod
+    @staticmethod
     def save_samples_to_file(
-        cls, data_dir: Union[str, Path], fold: DataFold, samples: Iterable[SampleType]
+        data_dir: Union[str, Path], fold: DataFold, samples: Iterable[SampleType]
     ) -> None:
         with open(DiskReactionDataset.get_data_path(data_dir=data_dir, fold=fold), "wt") as f:
             for sample in samples:

--- a/syntheseus/tests/reaction_prediction/data/test_dataset.py
+++ b/syntheseus/tests/reaction_prediction/data/test_dataset.py
@@ -1,7 +1,16 @@
-import pytest
+import csv
 from pathlib import Path
 
-from syntheseus.reaction_prediction.data.dataset import DataFold, DiskReactionDataset
+import pytest
+
+from syntheseus.interface.bag import Bag
+from syntheseus.interface.molecule import Molecule
+from syntheseus.reaction_prediction.data.dataset import (
+    CSV_REACTION_SMILES_COLUMN_NAME,
+    DataFold,
+    DataFormat,
+    DiskReactionDataset,
+)
 from syntheseus.reaction_prediction.data.reaction_sample import ReactionSample
 
 
@@ -18,8 +27,79 @@ def test_save_and_load(tmp_path: Path, mapped: bool) -> None:
     for fold in DataFold:
         DiskReactionDataset.save_samples_to_file(data_dir=tmp_path, fold=fold, samples=samples)
 
-    # Now try to load the data we just saved.
-    dataset = DiskReactionDataset(tmp_path, sample_cls=ReactionSample)
+    for load_format in [None, DataFormat.JSONL]:
+        # Now try to load the data we just saved.
+        dataset = DiskReactionDataset(tmp_path, sample_cls=ReactionSample, data_format=load_format)
 
-    for fold in DataFold:
-        assert list(dataset[fold]) == samples
+        for fold in DataFold:
+            assert list(dataset[fold]) == samples
+
+
+@pytest.mark.parametrize("format", [DataFormat.CSV, DataFormat.SMILES])
+def test_load_external_format(tmp_path: Path, format: DataFormat) -> None:
+    # Example reaction SMILES, purposefully using non-canonical forms of reactants and product.
+    reaction_smiles = (
+        "[cH:1]1[cH:2][c:3]([CH3:4])[cH:5][cH:6][c:7]1Br.B(O)(O)[c:8]1[cH:9][cH:10][c:11]([CH3:12])[cH:13][cH:14]1>>"
+        "[cH:1]1[cH:2][c:3]([CH3:4])[cH:5][cH:6][c:7]1[c:8]2[cH:14][cH:13][c:11]([CH3:12])[cH:10][cH:9]2"
+    )
+
+    filename = DiskReactionDataset.get_filename_suffix(format=format, fold=DataFold.TRAIN)
+    with open(tmp_path / filename, "wt") as f:
+        if format == DataFormat.CSV:
+            writer = csv.DictWriter(f, fieldnames=["id", "class", CSV_REACTION_SMILES_COLUMN_NAME])
+            writer.writeheader()
+            writer.writerow(
+                {"id": 0, "class": "UNK", CSV_REACTION_SMILES_COLUMN_NAME: reaction_smiles}
+            )
+        else:
+            f.write(f"{reaction_smiles}\n")
+
+    for load_format in [None, format]:
+        dataset = DiskReactionDataset(tmp_path, sample_cls=ReactionSample, data_format=load_format)
+        assert dataset.get_num_samples(DataFold.TRAIN) == 1
+
+        samples = list(dataset[DataFold.TRAIN])
+        assert len(samples) == 1
+
+        [sample] = samples
+
+        # After loading, the reactants and products should be in canonical SMILES form, with the
+        # atom mapping removed.
+        assert sample == ReactionSample(
+            reactants=Bag([Molecule("Cc1ccc(Br)cc1"), Molecule("Cc1ccc(B(O)O)cc1")]),
+            products=Bag([Molecule("Cc1ccc(-c2ccc(C)cc2)cc1")]),
+        )
+
+        # The original reaction SMILES should have been saved separately.
+        assert sample.mapped_reaction_smiles == reaction_smiles
+
+
+@pytest.mark.parametrize("format", [DataFormat.JSONL, DataFormat.CSV, DataFormat.SMILES])
+def test_format_detection(tmp_path: Path, format: DataFormat) -> None:
+    other_format = (set(DataFormat) - {format}).pop()
+
+    # Create two files with different extensions, so that it is ambiguous which format we want.
+    (tmp_path / DiskReactionDataset.get_filename_suffix(format, DataFold.TRAIN)).touch()
+    (tmp_path / DiskReactionDataset.get_filename_suffix(other_format, DataFold.TEST)).touch()
+
+    # Loading with automatic resolution should fail.
+    with pytest.raises(ValueError):
+        DiskReactionDataset(data_dir=tmp_path, sample_cls=ReactionSample)
+
+    # Loading with an explicit format should succeed.
+    for f in [format, other_format]:
+        DiskReactionDataset(data_dir=tmp_path, sample_cls=ReactionSample, data_format=f)
+
+    # Loading with an explicit format but no matching files should fail.
+    another_format = (set(DataFormat) - {format, other_format}).pop()
+    with pytest.raises(ValueError):
+        DiskReactionDataset(
+            data_dir=tmp_path, sample_cls=ReactionSample, data_format=another_format
+        )
+
+    # Create another file with the right suffix.
+    (tmp_path / f"raw_{DiskReactionDataset.get_filename_suffix(format, DataFold.TRAIN)}").touch()
+
+    # Loading with an explicit format should now fail due to ambiguity.
+    with pytest.raises(ValueError):
+        DiskReactionDataset(data_dir=tmp_path, sample_cls=ReactionSample, data_format=format)

--- a/syntheseus/tests/reaction_prediction/data/test_dataset.py
+++ b/syntheseus/tests/reaction_prediction/data/test_dataset.py
@@ -1,16 +1,14 @@
 import pytest
+from pathlib import Path
 
 from syntheseus.reaction_prediction.data.dataset import DataFold, DiskReactionDataset
 from syntheseus.reaction_prediction.data.reaction_sample import ReactionSample
 
 
 @pytest.mark.parametrize("mapped", [False, True])
-def test_save_and_load(tmp_path, mapped):
-    sample_cls = ReactionSample
-    sample_kwargs = {}
-
+def test_save_and_load(tmp_path: Path, mapped: bool) -> None:
     samples = [
-        sample_cls.from_reaction_smiles_strict(reaction_smiles, mapped=mapped, **sample_kwargs)
+        ReactionSample.from_reaction_smiles_strict(reaction_smiles, mapped=mapped)
         for reaction_smiles in [
             "O[c:1]1[cH:2][c:3](=[O:4])[nH:5][cH:6][cH:7]1>>[cH:1]1[cH:2][c:3](=[O:4])[nH:5][cH:6][cH:7]1",
             "CC(C)(C)OC(=O)[N:1]1[CH2:2][CH2:3][C@H:4]([F:5])[CH2:6]1>>[NH:1]1[CH2:2][CH2:3][C@H:4]([F:5])[CH2:6]1",
@@ -21,7 +19,7 @@ def test_save_and_load(tmp_path, mapped):
         DiskReactionDataset.save_samples_to_file(data_dir=tmp_path, fold=fold, samples=samples)
 
     # Now try to load the data we just saved.
-    dataset = DiskReactionDataset(tmp_path, sample_cls=sample_cls)
+    dataset = DiskReactionDataset(tmp_path, sample_cls=ReactionSample)
 
     for fold in DataFold:
         assert list(dataset[fold]) == samples

--- a/syntheseus/tests/reaction_prediction/data/test_dataset.py
+++ b/syntheseus/tests/reaction_prediction/data/test_dataset.py
@@ -1,10 +1,6 @@
 import pytest
 
-from syntheseus.reaction_prediction.data.dataset import (
-    DataFold,
-    DiskReactionDataset,
-    ReactionDataset,
-)
+from syntheseus.reaction_prediction.data.dataset import DataFold, DiskReactionDataset
 from syntheseus.reaction_prediction.data.reaction_sample import ReactionSample
 
 
@@ -22,7 +18,7 @@ def test_save_and_load(tmp_path, mapped):
     ]
 
     for fold in DataFold:
-        ReactionDataset.save_samples_to_file(data_dir=tmp_path, fold=fold, samples=samples)
+        DiskReactionDataset.save_samples_to_file(data_dir=tmp_path, fold=fold, samples=samples)
 
     # Now try to load the data we just saved.
     dataset = DiskReactionDataset(tmp_path, sample_cls=sample_cls)


### PR DESCRIPTION
Currently, running single-step evaluation requires supplying data in our special `*.jsonl` format. This means that a user needs to understand how the format is structured, and then convert their existing data. Instead of adding a conversion script, this PR extends the `DiskReactionDataset` class to support two additional formats: a csv-based one, commonly used to store raw USPTO-50K data, and a raw list-of-reaction-SMILES format. By default the right format is selected automatically based on the files present in the given directory. This allows running evaluation using the raw USPTO-50K data available on the web as-is. Moreover, converting from another format to the JSONL-based one is now just a matter of loading the data through the `DiskReactionDataset` class and then re-saving.