### PR TITLE
Add function to check if there is a route with a given set of starting molecules

### DIFF
--- a/syntheseus/search/analysis/starting_molecule_match.py
+++ b/syntheseus/search/analysis/starting_molecule_match.py
@@ -1,0 +1,62 @@
+"""Code related to starting molecules match metric (called exact set-wise match in FusionRetro)."""
+
+from __future__ import annotations
+
+import itertools
+import typing
+from collections.abc import Iterable
+
+T = typing.TypeVar("T")
+
+
+def partition_set(A: list[T], k: int) -> Iterable[list[list[T]]]:
+    """
+    Enumerates all possible ways to partition a list A into k disjoint subsets which are non-empty
+    (in all possible orders).
+
+    This function is easiest to explain by example:
+
+    A single partition is just the list A itself.
+
+    >>> list(partition_set([1, 2, 3], 1))
+    >>> [[[1, 2, 3]]]
+
+    For k=2, there are 3 possible partitions each with two possible orders.
+
+    >>> list(partition_set([1, 2, 3], 2))
+    >>> [[[1], [2, 3]], [[2], [1, 3]], [[3], [1, 2]], [[1, 2], [3]], [[1, 3], [2]], [[2, 3], [1]]]
+
+    For k=3, there is only 1 possible partition but 6 possible orders.
+
+    >>> list(partition_set([1, 2, 3], 3))
+    >>> [[[1], [2], [3]], [[1], [3], [2]], [[2], [1], [3]], [[2], [3], [1]], [[3], [1], [2]], [[3], [2], [1]]]
+
+    This function uses a recursive implementation.
+    First it partitions A into 2 (where the second partition has at least k-1 elements),
+    then it recursively partitions the second partition into (k-1) partitions.
+    """
+
+    # Check 1: elements of list are unique
+    assert len(set(A)) == len(A)
+
+    # Check 2: k is valid
+    assert k >= 1
+
+    # Base case 1: list is empty
+    if len(A) == 0:
+        return
+
+    # Base case 2: just a single partition
+    if k == 1:
+        yield [A]
+        return
+
+    # Main case: partition A into two parts, then recursively partition the second part
+    max_size_of_first_partition = len(A) - k + 1
+    for first_partition_size in range(1, max_size_of_first_partition + 1):
+        for first_partition in itertools.combinations(A, first_partition_size):
+            # Find the remaining elements to partition.
+            # NOTE: this assumes that the elements of A are unique.
+            remaining_elements = [x for x in A if x not in first_partition]
+            for subsequent_partitions in partition_set(remaining_elements, k - 1):
+                yield [list(first_partition)] + subsequent_partitions

--- a/syntheseus/search/analysis/starting_molecule_match.py
+++ b/syntheseus/search/analysis/starting_molecule_match.py
@@ -6,7 +6,26 @@ import itertools
 import typing
 from collections.abc import Iterable
 
+from syntheseus.search.chem import Molecule
+from syntheseus.search.graph.and_or import ANDOR_NODE, AndOrGraph, OrNode
+
 T = typing.TypeVar("T")
+
+
+def is_route_with_starting_mols(
+    graph: AndOrGraph,
+    starting_mols: set[Molecule],
+    forbidden_nodes: typing.Optional[set[ANDOR_NODE]] = None,
+) -> bool:
+    """Checks whether there is a route in graph matching the starting mols."""
+    forbidden_nodes = forbidden_nodes or set()
+    return _is_route_with_starting_mols(
+        graph,
+        graph.root_node,
+        starting_mols,
+        forbidden_nodes,
+        _starting_mols_under_each_node(graph),
+    )
 
 
 def partition_set(A: list[T], k: int) -> Iterable[list[list[T]]]:
@@ -60,3 +79,88 @@ def partition_set(A: list[T], k: int) -> Iterable[list[list[T]]]:
             remaining_elements = [x for x in A if x not in first_partition]
             for subsequent_partitions in partition_set(remaining_elements, k - 1):
                 yield [list(first_partition)] + subsequent_partitions
+
+
+def _starting_mols_under_each_node(graph: AndOrGraph) -> dict[ANDOR_NODE, set[Molecule]]:
+    """Get set of molecules reachable under each node in the graph."""
+
+    # Initialize to empty sets, except for nodes with purchasable mols
+    node_to_mols: dict[ANDOR_NODE, set[Molecule]] = {n: set() for n in graph.nodes()}
+    for n in graph.nodes():
+        if isinstance(n, OrNode):
+            node_to_mols[n].add(n.mol)
+
+    # Do passes through all nodes
+    update_happened = True
+    while update_happened:
+        update_happened = False
+        for n in graph.nodes():
+            for c in graph.successors(n):
+                if not (node_to_mols[c] <= node_to_mols[n]):
+                    node_to_mols[n].update(node_to_mols[c])
+                    update_happened = True
+
+    return node_to_mols
+
+
+def _is_route_with_starting_mols(
+    graph: AndOrGraph,
+    start_node: OrNode,
+    starting_mols: set[Molecule],
+    forbidden_nodes: set[ANDOR_NODE],
+    node_to_all_reachable_starting_mols: dict[ANDOR_NODE, set[Molecule]],
+) -> bool:
+    """
+    Recursive method to check whether there is a route in the graph,
+    starting from `start_node` and excluding `forbidden_nodes`,
+    whose leaves and exactly `starting_mols`.
+
+    To prune the search, we use the `node_to_all_reachable_starting_mols` dictionary,
+    which contains the set of all purchasable molecules reachable under each node (not necessarily part of a single route though).
+    We use this to prune the search early: if some molecules cannot be reached at all, there is no point checking whether
+    they might be reachable from a single route.
+    """
+    assert start_node in graph
+
+    # Base case 1: starting mols is empty
+    if len(starting_mols) == 0:
+        return False
+
+    # Base case 2: start node is forbidden
+    if start_node in forbidden_nodes:
+        return False
+
+    # Base case 3: starting are not reachable at all from the start node
+    if not (starting_mols <= node_to_all_reachable_starting_mols[start_node]):
+        return False
+
+    # Base case 4: there is just one starting molecule and this OrNode contains it.
+    if len(starting_mols) == 1 and list(starting_mols)[0] == start_node.mol:
+        return True
+
+    # Main case: the required starting molecules are reachable,
+    # but we just need to check whether they are reachable within a single synthesis route.
+    # We do this by explicitly trying to find this synthesis route.
+    for rxn_child in graph.successors(start_node):
+        # If the starting molecules are not reachable from this reaction child, abort the search
+        if node_to_all_reachable_starting_mols[rxn_child] >= starting_mols:
+            # Also abort search if any grandchildren are forbidden
+            grandchildren = list(graph.successors(rxn_child))
+            if not any(gc in forbidden_nodes for gc in grandchildren):
+                # Main recurisve call: we partition K molecules among N children and check whether
+                for start_mol_partition in partition_set(list(starting_mols), len(grandchildren)):
+                    for gc, allocated_start_mols in zip(grandchildren, start_mol_partition):
+                        assert isinstance(gc, OrNode)
+                        if not _is_route_with_starting_mols(
+                            graph,
+                            gc,
+                            set(allocated_start_mols),
+                            forbidden_nodes | {start_node, rxn_child},
+                            node_to_all_reachable_starting_mols,
+                        ):
+                            break
+                    else:  # i.e. loop finished without breaking
+                        return True
+
+    # If the method has not returned at this point then there is no route
+    return False

--- a/syntheseus/tests/search/analysis/test_starting_molecule_match.py
+++ b/syntheseus/tests/search/analysis/test_starting_molecule_match.py
@@ -8,59 +8,30 @@ from syntheseus.search.graph.and_or import AndOrGraph
 @pytest.mark.parametrize(
     "A,k,expected_partitions",
     [
-        ([1, 2, 3], 1, [[[1, 2, 3]]]),
         (
-            [1, 2, 3],
-            2,
-            [
-                [[1], [2, 3]],
-                [[2], [1, 3]],
-                [[3], [1, 2]],
-                [[1, 2], [3]],
-                [[1, 3], [2]],
-                [[2, 3], [1]],
-            ],
+            [1, 2],
+            1,
+            [[[1, 2]]],
         ),
         (
-            [1, 2, 3],
-            3,
-            [
-                [[1], [2], [3]],
-                [[1], [3], [2]],
-                [[2], [1], [3]],
-                [[2], [3], [1]],
-                [[3], [1], [2]],
-                [[3], [2], [1]],
-            ],
-        ),
-        ([1, 2, 3], 4, []),
-        ([1, 2, 3], 5, []),
-        (
-            [1, 2, 3, 4],
+            [1, 2],
             2,
             [
-                [[1], [2, 3, 4]],
-                [[2], [1, 3, 4]],
-                [[3], [1, 2, 4]],
-                [[4], [1, 2, 3]],
-                [[1, 2], [3, 4]],
-                [[1, 3], [2, 4]],
-                [[1, 4], [2, 3]],
-                [[2, 3], [1, 4]],
-                [[2, 4], [1, 3]],
-                [[3, 4], [1, 2]],
-                [[1, 2, 3], [4]],
-                [[1, 2, 4], [3]],
-                [[1, 3, 4], [2]],
-                [[2, 3, 4], [1]],
+                [[1], [2]],
+                [[1], [1, 2]],
+                [[2], [1]],
+                [[2], [1, 2]],
+                [[1, 2], [1]],
+                [[1, 2], [2]],
+                [[1, 2], [1, 2]],
             ],
         ),
         ([], 1, []),  # empty list has no partitions
         ([], 2, []),  # test again with k=2
     ],
 )
-def test_partition_set_valid(A, k, expected_partitions):
-    output = list(starting_molecule_match.partition_set(A, k))
+def test_split_into_subsets_valid(A, k, expected_partitions):
+    output = list(starting_molecule_match.split_into_subsets(A, k))
     assert output == expected_partitions
 
 
@@ -72,9 +43,9 @@ def test_partition_set_valid(A, k, expected_partitions):
         ([1, 2, 2], 0),  # list has duplicates
     ],
 )
-def test_partition_set_invalid(A, k):
+def test_split_into_subsets_invalid(A, k):
     with pytest.raises(AssertionError):
-        list(starting_molecule_match.partition_set(A, k))
+        list(starting_molecule_match.split_into_subsets(A, k))
 
 
 class TestStartingMoleculeMatch:

--- a/syntheseus/tests/search/analysis/test_starting_molecule_match.py
+++ b/syntheseus/tests/search/analysis/test_starting_molecule_match.py
@@ -65,12 +65,10 @@ class TestStartingMoleculeMatch:
         self, andor_graph_non_minimal: AndOrGraph, starting_smiles: str, expected_ans: bool
     ):
         starting_mols = {Molecule(s) for s in starting_smiles.split(".")}
-        assert (
-            starting_molecule_match.is_route_with_starting_mols(
-                andor_graph_non_minimal, starting_mols
-            )
-            == expected_ans
+        match = starting_molecule_match.is_route_with_starting_mols(
+            andor_graph_non_minimal, starting_mols
         )
+        assert match == expected_ans
 
     @pytest.mark.parametrize(
         "starting_smiles,expected_ans",
@@ -88,9 +86,7 @@ class TestStartingMoleculeMatch:
         self, andor_graph_with_many_routes: AndOrGraph, starting_smiles: str, expected_ans: bool
     ):
         starting_mols = {Molecule(s) for s in starting_smiles.split(".")}
-        assert (
-            starting_molecule_match.is_route_with_starting_mols(
-                andor_graph_with_many_routes, starting_mols
-            )
-            == expected_ans
+        match = starting_molecule_match.is_route_with_starting_mols(
+            andor_graph_with_many_routes, starting_mols
         )
+        assert match == expected_ans

--- a/syntheseus/tests/search/analysis/test_starting_molecule_match.py
+++ b/syntheseus/tests/search/analysis/test_starting_molecule_match.py
@@ -1,0 +1,75 @@
+import pytest
+
+from syntheseus.search.analysis import starting_molecule_match
+
+
+@pytest.mark.parametrize(
+    "A,k,expected_partitions",
+    [
+        ([1, 2, 3], 1, [[[1, 2, 3]]]),
+        (
+            [1, 2, 3],
+            2,
+            [
+                [[1], [2, 3]],
+                [[2], [1, 3]],
+                [[3], [1, 2]],
+                [[1, 2], [3]],
+                [[1, 3], [2]],
+                [[2, 3], [1]],
+            ],
+        ),
+        (
+            [1, 2, 3],
+            3,
+            [
+                [[1], [2], [3]],
+                [[1], [3], [2]],
+                [[2], [1], [3]],
+                [[2], [3], [1]],
+                [[3], [1], [2]],
+                [[3], [2], [1]],
+            ],
+        ),
+        ([1, 2, 3], 4, []),
+        ([1, 2, 3], 5, []),
+        (
+            [1, 2, 3, 4],
+            2,
+            [
+                [[1], [2, 3, 4]],
+                [[2], [1, 3, 4]],
+                [[3], [1, 2, 4]],
+                [[4], [1, 2, 3]],
+                [[1, 2], [3, 4]],
+                [[1, 3], [2, 4]],
+                [[1, 4], [2, 3]],
+                [[2, 3], [1, 4]],
+                [[2, 4], [1, 3]],
+                [[3, 4], [1, 2]],
+                [[1, 2, 3], [4]],
+                [[1, 2, 4], [3]],
+                [[1, 3, 4], [2]],
+                [[2, 3, 4], [1]],
+            ],
+        ),
+        ([], 1, []),  # empty list has no partitions
+        ([], 2, []),  # test again with k=2
+    ],
+)
+def test_partition_set_valid(A, k, expected_partitions):
+    output = list(starting_molecule_match.partition_set(A, k))
+    assert output == expected_partitions
+
+
+@pytest.mark.parametrize(
+    "A,k",
+    [
+        ([1, 2, 3], -1),  # negative k
+        ([1, 2, 3], 0),  # k=0
+        ([1, 2, 2], 0),  # list has duplicates
+    ],
+)
+def test_partition_set_invalid(A, k):
+    with pytest.raises(AssertionError):
+        list(starting_molecule_match.partition_set(A, k))

--- a/syntheseus/tests/search/analysis/test_starting_molecule_match.py
+++ b/syntheseus/tests/search/analysis/test_starting_molecule_match.py
@@ -1,6 +1,8 @@
 import pytest
 
 from syntheseus.search.analysis import starting_molecule_match
+from syntheseus.search.chem import Molecule
+from syntheseus.search.graph.and_or import AndOrGraph
 
 
 @pytest.mark.parametrize(
@@ -73,3 +75,51 @@ def test_partition_set_valid(A, k, expected_partitions):
 def test_partition_set_invalid(A, k):
     with pytest.raises(AssertionError):
         list(starting_molecule_match.partition_set(A, k))
+
+
+class TestStartingMoleculeMatch:
+    @pytest.mark.parametrize(
+        "starting_smiles,expected_ans",
+        [
+            ("COCS", True),  # Is starting molecule
+            ("CO.CS", True),  # One of the routes
+            ("CC", True),  # Another route
+            ("CS.CC", True),  # Another route
+            ("CO.CC", True),  # Can be a route if CO occurs twice and is reacted in one of them
+            ("COCC.CC", False),  # both mols are in graph, but not part of same route
+            ("", False),  # an empty set should always be False
+        ],
+    )
+    def test_small_andorgraph(
+        self, andor_graph_non_minimal: AndOrGraph, starting_smiles: str, expected_ans: bool
+    ):
+        starting_mols = {Molecule(s) for s in starting_smiles.split(".")}
+        assert (
+            starting_molecule_match.is_route_with_starting_mols(
+                andor_graph_non_minimal, starting_mols
+            )
+            == expected_ans
+        )
+
+    @pytest.mark.parametrize(
+        "starting_smiles,expected_ans",
+        [
+            ("CC.COC", True),  # small route, should be in there
+            ("CCCO.O", True),  # another route from docstring
+            ("CCCO.C", True),  # this route exists (although C is not purchasable here)
+            ("CCCOC", True),  # this is just the root node
+            ("", False),  # an empty set should always be False
+            ("C.O", True),  # should be possible to decompose into just C,O
+            ("CCCO.CC", False),  # too many atoms
+        ],
+    )
+    def test_large_andorgraph(
+        self, andor_graph_with_many_routes: AndOrGraph, starting_smiles: str, expected_ans: bool
+    ):
+        starting_mols = {Molecule(s) for s in starting_smiles.split(".")}
+        assert (
+            starting_molecule_match.is_route_with_starting_mols(
+                andor_graph_with_many_routes, starting_mols
+            )
+            == expected_ans
+        )

--- a/syntheseus/tests/search/conftest.py
+++ b/syntheseus/tests/search/conftest.py
@@ -248,7 +248,7 @@ def retrosynthesis_task6() -> RetrosynthesisTask:
     CCCOC -> CC + COC
 
     There are 2 routes of length 2:
-    CCCO -> CCCO + C
+    CCCOC -> CCCO + C
     C -> O
 
     CCCOC -> CCCOO


### PR DESCRIPTION
In the paper [FusionRetro](https://proceedings.mlr.press/v202/liu23ah.html) they proposed checking whether the starting molecules for a route found during multi-step planning match the starting materials used in an actual synthesis route. This is essentially a less strict version of checking whether an exact ground-truth route is found. This PR implements code to check for the existence of a route with a specific set of starting materials.

In FusionRetro this metric is called "set-wise exact match", however this name is very vague so I instead called it `is_route_with_starting_mols`. I only wrote a version for AND/OR graphs because these typically contain a prohibitively large number of routes to explicitly enumerate them. The method is essentially a brute-force search with pruning of search branches. The inner workings of the methods are described reasonably-well in the docstrings (but I want to improve the description before merging)

I also fixed a random typo in a `conftest.py` docstring that I found while writing tests.

**TODO**:

- I need to add a CHANGELOG entry for this.
- should appr
- Check that pruned search works reasonably well in practice