### PR TITLE
Extend the single-step evaluation script with further metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Added
 - Add code for PDVN MCTS and extracting training data for policies and value functions ([#8](https://github.com/microsoft/syntheseus/pull/8)) ([@austint], [@fiberleif])
 - Add a top-level CLI for running end-to-end search ([#26](https://github.com/microsoft/syntheseus/pull/26)) ([@kmaziarz])
-- Release single-step evaluation framework and wrappers for several model types ([#14](https://github.com/microsoft/syntheseus/pull/14), [#15](https://github.com/microsoft/syntheseus/pull/15), [#20](https://github.com/microsoft/syntheseus/pull/20), [#32](https://github.com/microsoft/syntheseus/pull/32)) ([@kmaziarz])
+- Release single-step evaluation framework and wrappers for several model types ([#14](https://github.com/microsoft/syntheseus/pull/14), [#15](https://github.com/microsoft/syntheseus/pull/15), [#20](https://github.com/microsoft/syntheseus/pull/20), [#32](https://github.com/microsoft/syntheseus/pull/32), [#35](https://github.com/microsoft/syntheseus/pull/35)) ([@kmaziarz])
 - Release checkpoints for all supported single-step model types ([#21](https://github.com/microsoft/syntheseus/pull/21)) ([@kmaziarz])
 - Support `*.csv` and `*.smi` formats for the single-step evaluation data ([#33](https://github.com/microsoft/syntheseus/pull/33)) ([@kmaziarz])
 - Implement node evaluators commonly used in MCTS and Retro* ([#23](https://github.com/microsoft/syntheseus/pull/23), [#27](https://github.com/microsoft/syntheseus/pull/27)) ([@kmaziarz])

--- a/syntheseus/interface/models.py
+++ b/syntheseus/interface/models.py
@@ -31,7 +31,10 @@ class Prediction(GenericModel, Generic[InputType, OutputType]):
     score: Optional[float] = None  # Any other score.
     reaction: Optional[str] = None  # Reaction smiles.
     rxnid: Optional[int] = None  # Template id, if applicable.
-    metadata: Dict[str, Any] = {}  # Additional metadata.
+
+    # Dictionary to hold additional metadata. Note that we use a mutable default value here, which
+    # could be a problem in plain Python, but is handled correctly by `pydantic`.
+    metadata: Dict[str, Any] = {}
 
     def get_prob(self) -> float:
         if self.probability is not None:
@@ -67,6 +70,8 @@ class PredictionList(GenericModel, Generic[InputType, OutputType]):
 
     input: InputType
     predictions: List[Prediction[InputType, OutputType]]
+
+    # Dictionary to hold additional metadata (see note above regarding the mutable default value).
     metadata: Dict[str, Any] = {}
 
     def truncated(self, num_results: int) -> PredictionList[InputType, OutputType]:

--- a/syntheseus/interface/models.py
+++ b/syntheseus/interface/models.py
@@ -31,7 +31,7 @@ class Prediction(GenericModel, Generic[InputType, OutputType]):
     score: Optional[float] = None  # Any other score.
     reaction: Optional[str] = None  # Reaction smiles.
     rxnid: Optional[int] = None  # Template id, if applicable.
-    metadata: Optional[Dict[str, Any]] = {}  # Additional metadata.
+    metadata: Dict[str, Any] = {}  # Additional metadata.
 
     def get_prob(self) -> float:
         if self.probability is not None:
@@ -67,7 +67,7 @@ class PredictionList(GenericModel, Generic[InputType, OutputType]):
 
     input: InputType
     predictions: List[Prediction[InputType, OutputType]]
-    metadata: Optional[Dict[str, Any]] = {}
+    metadata: Dict[str, Any] = {}
 
     def truncated(self, num_results: int) -> PredictionList[InputType, OutputType]:
         fields = self.dict()

--- a/syntheseus/reaction_prediction/cli/eval.py
+++ b/syntheseus/reaction_prediction/cli/eval.py
@@ -426,8 +426,8 @@ def compute_metrics(
         mrr=ground_truth_match_metrics.mrr,
         min_num_predictions=min(num_predictions),
         max_num_predictions=max(num_predictions),
-        mean_num_predictions=mean(num_predictions),
-        median_num_predictions=median(num_predictions),
+        mean_num_predictions=float(mean(num_predictions)),
+        median_num_predictions=float(median(num_predictions)),
         model_time_total=compute_total_time(model_timing_results),
         **extra_args,
     )

--- a/syntheseus/reaction_prediction/cli/eval.py
+++ b/syntheseus/reaction_prediction/cli/eval.py
@@ -339,6 +339,11 @@ def compute_metrics(
             ]
             ground_truth_match_metrics.add(ground_truth_matches)
 
+            for prediction, ground_truth_match in zip(
+                prediction_list.predictions, ground_truth_matches
+            ):
+                prediction.metadata["ground_truth_match"] = ground_truth_match
+
             if back_translation_model is not None:
                 assert back_translation_metrics is not None
                 assert back_translation_combined_metrics is not None

--- a/syntheseus/reaction_prediction/cli/eval.py
+++ b/syntheseus/reaction_prediction/cli/eval.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field, fields
 from enum import Enum
 from functools import partial
 from itertools import islice
+from statistics import mean, median
 from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Set, Union, cast
 
 import numpy as np
@@ -148,6 +149,10 @@ class EvalResults:
     num_samples: int
     top_k: List[float]
     mrr: float
+    min_num_predictions: int
+    max_num_predictions: int
+    mean_num_predictions: float
+    median_num_predictions: float
     model_time_total: ModelTimingResults
     back_translation_top_k: Optional[List[float]] = None
     back_translation_mrr: Optional[float] = None
@@ -290,6 +295,8 @@ def compute_metrics(
     test_dataset: Iterable[ReactionSample] = dataset[fold]
     test_dataset_size = dataset.get_num_samples(fold)
 
+    num_predictions: List[int] = []
+
     if num_dataset_truncation is not None and num_dataset_truncation < test_dataset_size:
         print(
             f"Truncating the dataset from {test_dataset_size} to {num_dataset_truncation} samples"
@@ -334,6 +341,8 @@ def compute_metrics(
 
         batch_back_translation_predictions: List[List[PredictionList]] = []
         for input, output, prediction_list in zip(inputs, outputs, batch_predictions):
+            num_predictions.append(len(prediction_list.predictions))
+
             ground_truth_matches = [
                 prediction.output == output for prediction in prediction_list.predictions
             ]
@@ -415,6 +424,10 @@ def compute_metrics(
         num_samples=ground_truth_match_metrics.num_samples,
         top_k=ground_truth_match_metrics.top_k,
         mrr=ground_truth_match_metrics.mrr,
+        min_num_predictions=min(num_predictions),
+        max_num_predictions=max(num_predictions),
+        mean_num_predictions=mean(num_predictions),
+        median_num_predictions=median(num_predictions),
         model_time_total=compute_total_time(model_timing_results),
         **extra_args,
     )

--- a/syntheseus/tests/reaction_prediction/cli/test_eval.py
+++ b/syntheseus/tests/reaction_prediction/cli/test_eval.py
@@ -91,6 +91,10 @@ def test_print_and_save():
         num_samples=1,
         top_k=[0.0] * 50,
         mrr=0.0,
+        min_num_predictions=1,
+        max_num_predictions=50,
+        mean_num_predictions=25.0,
+        median_num_predictions=10.0,
         model_time_total=ModelTimingResults(time_model_call=1.0, time_post_processing=0.1),
         predictions=[
             BackwardPredictionList(


### PR DESCRIPTION
This PR improves the reaction prediction evaluation script with two small extensions:
- attaching a `ground_truth_match` flag to the predictions to mark the ones that were judged as ground truth
- tracking the number of model predictions and reporting its simple statistics (for a variety of reasons the evaluated model may return less distinct outputs than was requested)