### PR TITLE
Add method to get starting molecules from synthesis route.

### DIFF
--- a/syntheseus/search/graph/route.py
+++ b/syntheseus/search/graph/route.py
@@ -61,5 +61,18 @@ class SynthesisGraph(BaseReactionGraph[BackwardReaction]):
     ) -> Sequence[BackwardReaction]:
         raise NotImplementedError
 
+    def get_starting_molecules(self) -> set[Molecule]:
+        """
+        Get the 'starting molecules' for this route,
+        i.e. reactant molecules which are not a product of a child reaction.
+        """
+        output: set[Molecule] = set()
+        for rxn in self._graph.nodes:
+            successor_products = {rxn.product for rxn in self.successors(rxn)}
+            for reactant in rxn.reactants:
+                if reactant not in successor_products:
+                    output.add(reactant)
+        return output
+
     def __str__(self) -> str:
         return str([rxn.reaction_smiles for rxn in self.nodes()])

--- a/syntheseus/tests/search/graph/test_route.py
+++ b/syntheseus/tests/search/graph/test_route.py
@@ -1,1 +1,7 @@
-"""Route objects are tested implicity in other tests, so there are no specific tests at this time."""
+"""Route objects are tested implicity in other tests, so there are only minimal tests for now."""
+
+from syntheseus.search.chem import Molecule
+
+
+def test_route_starting_molecules(minimal_synthesis_graph):
+    assert minimal_synthesis_graph.get_starting_molecules() == {Molecule("CC")}


### PR DESCRIPTION
This is useful for various analysis techniques, e.g. the "starting molecule matching" metric from FusionRetro.

**TODO**: need to add CHANGELOG entry.