### PR TITLE
Unpin zipp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Adapt tutorials to the renaming from PR #9 ([#17](https://github.com/microsoft/syntheseus/pull/17)) ([@jagarridotorres])
 - Pin `pydantic` version to `1.*` ([#10](https://github.com/microsoft/syntheseus/pull/10)) ([@kmaziarz])
 - Fix compatibility with Python 3.7 ([#5](https://github.com/microsoft/syntheseus/pull/5)) ([@kmaziarz])
-- Pin `zipp` version to `<3.16` ([#11](https://github.com/microsoft/syntheseus/pull/11)) ([@kmaziarz])
 
 ## [0.1.0] - 2023-05-25
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,8 +17,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pre-commit
-  # Temporary pin to avoid the 3.16.0 release, which drops support for Python 3.7
-  - zipp<3.16
   - pip:
     # Additional dependencies of `syntheseus/reaction_prediction`
     - more_itertools


### PR DESCRIPTION
In #11, we pinned `zipp` - a library we don't even depend on directly - to `<3.16` due to an incompatibility with Python 3.7. It seems the issue got sorted out as we now get compatible versions without the pin (`3.15` for Python 3.7 and `3.17` for Python 3.9). This PR thus drops the pin for simplicity.