### PR TITLE
Fix security pipeline by removing a broken step

### DIFF
--- a/.github/azure_pipelines/code-security-analysis.yml
+++ b/.github/azure_pipelines/code-security-analysis.yml
@@ -15,14 +15,6 @@ steps:
 - task: CredScan@2
   inputs:
     toolMajorVersion: 'V2'
-- task: Semmle@1
-  inputs:
-    sourceCodeDirectory: '$(Build.SourcesDirectory)'
-    language: 'python'
-    querySuite: 'Recommended'
-    timeout: '1800'
-    ram: '16384'
-    addProjectDirToScanningExclusionList: true
 - task: ComponentGovernanceComponentDetection@0
   inputs:
     scanType: 'Register'


### PR DESCRIPTION
The security pipeline has been failing recently due to a broken Semmle step. This has not been fixed upstream for a few weeks, so in this PR I remove that step from the pipeline to make it pass again.