### PR TITLE
Fix some typos and unclear messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Pin `pydantic` version to `1.*` ([#10](https://github.com/microsoft/syntheseus/pull/10)) ([@kmaziarz])
 - Fix compatibility with Python 3.7 ([#5](https://github.com/microsoft/syntheseus/pull/5)) ([@kmaziarz])
 - Pin `zipp` version to `<3.16` ([#11](https://github.com/microsoft/syntheseus/pull/11)) ([@kmaziarz])
+- Correct some typos and unclear error messages ([#39](https://github.com/microsoft/syntheseus/pull/39)) ([@austint])
 
 ## [0.1.0] - 2023-05-25
 

--- a/syntheseus/search/graph/and_or.py
+++ b/syntheseus/search/graph/and_or.py
@@ -203,7 +203,7 @@ class AndOrGraph(RetrosynthesisSearchGraph[ANDOR_NODE]):
         root_reactions = list(subgraph.successors(self.root_node))
         assert (
             len(root_reactions) == 1
-        ), "There appears to be more than 1 reaction for the root node."
+        ), f"There appears to be {len(root_reactions)} reactions for the root node (expected exactly 1)."
         new_graph = SynthesisGraph(root_node=root_reactions[0].reaction)
 
         # Add all nodes and edges

--- a/syntheseus/tests/search/conftest.py
+++ b/syntheseus/tests/search/conftest.py
@@ -248,7 +248,7 @@ def retrosynthesis_task6() -> RetrosynthesisTask:
     CCCOC -> CC + COC
 
     There are 2 routes of length 2:
-    CCCO -> CCCO + C
+    CCCOC -> CCCO + C
     C -> O
 
     CCCOC -> CCCOO


### PR DESCRIPTION
First fix: error message for converting an AND/OR graph to a synthesis route would say there was more than one node if in fact there were zero nodes.

Second fix: reaction string in `conftest.py`. This was also fixed in #34, but since I am not merging that I decided to fix it here.