### PR TITLE
Add a simple CI for integration testing

### DIFF
--- a/.github/workflows/ci_single_step.yml
+++ b/.github/workflows/ci_single_step.yml
@@ -1,0 +1,27 @@
+name: CI (integration tests)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    name: build
+    steps:
+    - uses: actions/checkout@v3
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        mamba-version: "*"
+        channels: conda-forge,defaults
+        channel-priority: true
+        environment-file: environment_full.yml
+    - name: Install syntheseus with all single-step models
+      run: |
+        pip install .[all]


### PR DESCRIPTION
Following simplifications to single-step model setup in #41, this PR adds a minimalistic integration test, which for now just checks that doing `pip install .[all]` works. In the future this will be extended by running minimal single-step model inference and multi-step search using the supported models.