### PR TITLE
Refactor single-step evaluation script and move it to cli/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Simplify single-step model setup ([#41](https://github.com/microsoft/syntheseus/pull/41)) ([@kmaziarz])
+- Refactor single-step evaluation script and move it to cli/ ([#43](https://github.com/microsoft/syntheseus/pull/43)) ([@kmaziarz])
 
 ## [0.2.0] - 2023-11-21
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Additionally, we also support GLN, but that requires a specialized environment a
 
 ### Reducing the number of dependencies
 
-To keep the environment smaller, you can replace the `all` option with a comma-separated subset of `{chemformer,local-retro,megan,mhn-react,retro-knn,root-aligned,viz,dev}` (`viz` and `dev` correspond to visuzalisation and development dependencies, respectively).
+To keep the environment smaller, you can replace the `all` option with a comma-separated subset of `{chemformer,local-retro,megan,mhn-react,retro-knn,root-aligned,viz,dev}` (`viz` and `dev` correspond to visualization and development dependencies, respectively).
 For example, `pip install -e ".[local-retro,root-aligned]"` installs only LocalRetro and RootAligned.
 If installing a subset of models, you can also delete the lines in `environment_full.yml` marked with names of models you do not wish to use.
 

--- a/docs/cli/eval_single_step.md
+++ b/docs/cli/eval_single_step.md
@@ -5,7 +5,7 @@
 To run single-step model evaluation, run
 
 ```
-python ./retrosynthesis/reaction_prediction/cli/eval.py \
+python ./syntheseus/cli/eval.py \
     data_dir=[DATA_DIR] \
     model_class=[MODEL_CLASS] \
     model_dir=[MODEL_DIR]

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -4,7 +4,7 @@ Each of the model types can be loaded from a *single directory*, possibly contai
 (e.g. checkpoint, config, etc). See individual model wrappers for the model directory formats.
 
 Example invocation:
-    python ./retrosynthesis/reaction_prediction/cli/eval.py \
+    python ./cli/eval_single_step.py \
         data_dir=[DATA_DIR] \
         model_class=RetroKNN \
         model_dir=[MODEL_DIR]

--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -30,7 +30,8 @@ from omegaconf import MISSING, DictConfig, OmegaConf
 from tqdm import tqdm
 
 from syntheseus.interface.models import BackwardReactionModel
-from syntheseus.reaction_prediction.cli.eval import BackwardModelConfig, get_model
+from syntheseus.reaction_prediction.cli.eval import get_model
+from syntheseus.reaction_prediction.inference.config import BackwardModelConfig
 from syntheseus.reaction_prediction.utils.config import get_config as cli_get_config
 from syntheseus.reaction_prediction.utils.misc import set_random_seed
 from syntheseus.reaction_prediction.utils.syntheseus_wrapper import SyntheseusBackwardReactionModel

--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -30,10 +30,10 @@ from omegaconf import MISSING, DictConfig, OmegaConf
 from tqdm import tqdm
 
 from syntheseus.interface.models import BackwardReactionModel
-from syntheseus.reaction_prediction.cli.eval import get_model
 from syntheseus.reaction_prediction.inference.config import BackwardModelConfig
 from syntheseus.reaction_prediction.utils.config import get_config as cli_get_config
 from syntheseus.reaction_prediction.utils.misc import set_random_seed
+from syntheseus.reaction_prediction.utils.model_loading import get_model
 from syntheseus.reaction_prediction.utils.syntheseus_wrapper import SyntheseusBackwardReactionModel
 from syntheseus.search.algorithms.best_first.retro_star import RetroStarSearch
 from syntheseus.search.algorithms.mcts import base as mcts_base

--- a/syntheseus/reaction_prediction/cli/eval.py
+++ b/syntheseus/reaction_prediction/cli/eval.py
@@ -19,7 +19,6 @@ import math
 import os
 import time
 from dataclasses import dataclass, field, fields
-from enum import Enum
 from functools import partial
 from itertools import islice
 from statistics import mean, median
@@ -45,15 +44,7 @@ from syntheseus.reaction_prediction.data.dataset import (
     ReactionDataset,
 )
 from syntheseus.reaction_prediction.data.reaction_sample import ReactionSample
-from syntheseus.reaction_prediction.inference import (
-    ChemformerModel,
-    GLNModel,
-    LocalRetroModel,
-    MEGANModel,
-    MHNreactModel,
-    RetroKNNModel,
-    RootAlignedModel,
-)
+from syntheseus.reaction_prediction.inference.config import BackwardModelConfig, ForwardModelConfig
 from syntheseus.reaction_prediction.utils.config import get_config as cli_get_config
 from syntheseus.reaction_prediction.utils.metrics import (
     ModelTimingResults,
@@ -63,42 +54,6 @@ from syntheseus.reaction_prediction.utils.metrics import (
 from syntheseus.reaction_prediction.utils.misc import asdict_extended, set_random_seed
 
 logger = logging.getLogger(__file__)
-
-
-class ForwardModelClass(Enum):
-    Chemformer = ChemformerModel
-
-
-class BackwardModelClass(Enum):
-    Chemformer = ChemformerModel
-    GLN = GLNModel
-    LocalRetro = LocalRetroModel
-    MEGAN = MEGANModel
-    MHNreact = MHNreactModel
-    RetroKNN = RetroKNNModel
-    RootAligned = RootAlignedModel
-
-
-@dataclass
-class ModelConfig:
-    """Config for loading any reaction models, forward or backward."""
-
-    model_dir: str = MISSING
-    model_kwargs: Dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class ForwardModelConfig(ModelConfig):
-    """Config for loading one of the supported forward models."""
-
-    model_class: ForwardModelClass = MISSING
-
-
-@dataclass
-class BackwardModelConfig(ModelConfig):
-    """Config for loading one of the supported backward models."""
-
-    model_class: BackwardModelClass = MISSING
 
 
 @dataclass

--- a/syntheseus/reaction_prediction/cli/eval.py
+++ b/syntheseus/reaction_prediction/cli/eval.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field, fields
 from functools import partial
 from itertools import islice
 from statistics import mean, median
-from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Set, Union, cast
+from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Set, cast
 
 import numpy as np
 from more_itertools import batched
@@ -52,6 +52,7 @@ from syntheseus.reaction_prediction.utils.metrics import (
     compute_total_time,
 )
 from syntheseus.reaction_prediction.utils.misc import asdict_extended, set_random_seed
+from syntheseus.reaction_prediction.utils.model_loading import get_model
 
 logger = logging.getLogger(__file__)
 
@@ -439,35 +440,6 @@ def print_and_save(results: EvalResults, config: EvalConfig, suffix: str = "") -
 
         with open(outfile, "w") as outfile_stream:
             outfile_stream.write(json.dumps(results_dict))
-
-
-def get_model(
-    config: Union[BackwardModelConfig, ForwardModelConfig], batch_size: int, num_gpus: int
-) -> ReactionModel:
-    def model_fn(device):
-        return config.model_class.value(
-            model_dir=config.model_dir, device=device, **config.model_kwargs
-        )
-
-    if num_gpus == 0:
-        return model_fn("cpu")
-    elif num_gpus == 1:
-        return model_fn("cuda:0")
-    else:
-        if batch_size < num_gpus:
-            raise ValueError(f"Cannot split batch of size {batch_size} across {num_gpus} GPUs")
-
-        batch_size_per_gpu = batch_size // num_gpus
-
-        if batch_size_per_gpu < 16:
-            logger.warning(f"Batch size per GPU is very small: ~{batch_size_per_gpu}")
-
-        try:
-            from syntheseus.reaction_prediction.utils.parallel import ParallelReactionModel
-        except ModuleNotFoundError:
-            raise ValueError("Multi-GPU evaluation is only supported for torch-based models")
-
-        return ParallelReactionModel(model_fn, devices=[f"cuda:{idx}" for idx in range(num_gpus)])
 
 
 def run_from_config(

--- a/syntheseus/reaction_prediction/inference/config.py
+++ b/syntheseus/reaction_prediction/inference/config.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict
+
+from omegaconf import MISSING
+
+from syntheseus.reaction_prediction.inference import (
+    ChemformerModel,
+    GLNModel,
+    LocalRetroModel,
+    MEGANModel,
+    MHNreactModel,
+    RetroKNNModel,
+    RootAlignedModel,
+)
+
+
+class ForwardModelClass(Enum):
+    Chemformer = ChemformerModel
+
+
+class BackwardModelClass(Enum):
+    Chemformer = ChemformerModel
+    GLN = GLNModel
+    LocalRetro = LocalRetroModel
+    MEGAN = MEGANModel
+    MHNreact = MHNreactModel
+    RetroKNN = RetroKNNModel
+    RootAligned = RootAlignedModel
+
+
+@dataclass
+class ModelConfig:
+    """Config for loading any reaction models, forward or backward."""
+
+    model_dir: str = MISSING
+    model_kwargs: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ForwardModelConfig(ModelConfig):
+    """Config for loading one of the supported forward models."""
+
+    model_class: ForwardModelClass = MISSING
+
+
+@dataclass
+class BackwardModelConfig(ModelConfig):
+    """Config for loading one of the supported backward models."""
+
+    model_class: BackwardModelClass = MISSING

--- a/syntheseus/reaction_prediction/utils/model_loading.py
+++ b/syntheseus/reaction_prediction/utils/model_loading.py
@@ -1,0 +1,36 @@
+import logging
+from typing import Union
+
+from syntheseus.interface.models import ReactionModel
+from syntheseus.reaction_prediction.inference.config import BackwardModelConfig, ForwardModelConfig
+
+logger = logging.getLogger(__file__)
+
+
+def get_model(
+    config: Union[BackwardModelConfig, ForwardModelConfig], batch_size: int, num_gpus: int
+) -> ReactionModel:
+    def model_fn(device):
+        return config.model_class.value(
+            model_dir=config.model_dir, device=device, **config.model_kwargs
+        )
+
+    if num_gpus == 0:
+        return model_fn("cpu")
+    elif num_gpus == 1:
+        return model_fn("cuda:0")
+    else:
+        if batch_size < num_gpus:
+            raise ValueError(f"Cannot split batch of size {batch_size} across {num_gpus} GPUs")
+
+        batch_size_per_gpu = batch_size // num_gpus
+
+        if batch_size_per_gpu < 16:
+            logger.warning(f"Batch size per GPU is very small: ~{batch_size_per_gpu}")
+
+        try:
+            from syntheseus.reaction_prediction.utils.parallel import ParallelReactionModel
+        except ModuleNotFoundError:
+            raise ValueError("Multi-GPU evaluation is only supported for torch-based models")
+
+        return ParallelReactionModel(model_fn, devices=[f"cuda:{idx}" for idx in range(num_gpus)])

--- a/syntheseus/tests/reaction_prediction/cli/test_eval.py
+++ b/syntheseus/tests/reaction_prediction/cli/test_eval.py
@@ -12,12 +12,12 @@ from syntheseus.interface.models import (
 )
 from syntheseus.interface.molecule import Molecule
 from syntheseus.reaction_prediction.cli.eval import (
-    BackwardModelClass,
     EvalConfig,
     EvalResults,
     get_results,
     print_and_save,
 )
+from syntheseus.reaction_prediction.inference.config import BackwardModelClass
 from syntheseus.reaction_prediction.utils.metrics import ModelTimingResults
 
 

--- a/syntheseus/tests/reaction_prediction/cli/test_eval.py
+++ b/syntheseus/tests/reaction_prediction/cli/test_eval.py
@@ -4,6 +4,12 @@ from typing import Iterable, List
 
 import pytest
 
+from syntheseus.cli.eval_single_step import (
+    EvalConfig,
+    EvalResults,
+    get_results,
+    print_and_save,
+)
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.models import (
     BackwardPrediction,
@@ -11,12 +17,6 @@ from syntheseus.interface.models import (
     BackwardReactionModel,
 )
 from syntheseus.interface.molecule import Molecule
-from syntheseus.reaction_prediction.cli.eval import (
-    EvalConfig,
-    EvalResults,
-    get_results,
-    print_and_save,
-)
 from syntheseus.reaction_prediction.inference.config import BackwardModelClass
 from syntheseus.reaction_prediction.utils.metrics import ModelTimingResults
 


### PR DESCRIPTION
This PR includes a bit of cleanup and refactoring of the single-step evaluation script:
- Moved some parts (especially those imported by other files) out to separate utils files, in order to keep the length of the script a bit more manageable (the version currently on `main` has ~550 lines).
- Dropped the "combined" metric, which computed accuracy with success defined as "either the back-translation is successful _or_ the output matches the ground-truth". This was reported _on top of the individual back-translation and dataset-based accuracies_; after further thought I think such a combined metric is a bit complicated and overall adds clutter.
- Moved the refactored script from `syntheseus/reaction_prediction/cli` to `syntheseus/cli`, to make sure all CLI endpoints are equally accessible no matter which part of the underlying functionality they focus on. The associated `eval.md` documention I moved to a new `docs/` directory, which will later form the basis for building static documentation.

Finally, I also fixed a typo in `README.md`.