### PR TITLE
Add a general CLI endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add a general CLI endpoint ([#44](https://github.com/microsoft/syntheseus/pull/44)) ([@kmaziarz])
+
 ### Changed
 
 - Simplify single-step model setup ([#41](https://github.com/microsoft/syntheseus/pull/41)) ([@kmaziarz])

--- a/docs/cli/eval_single_step.md
+++ b/docs/cli/eval_single_step.md
@@ -5,7 +5,7 @@
 To run single-step model evaluation, run
 
 ```
-python ./syntheseus/cli/eval.py \
+syntheseus eval-single-step \
     data_dir=[DATA_DIR] \
     model_class=[MODEL_CLASS] \
     model_dir=[MODEL_DIR]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ all = [
   "syntheseus[viz,dev,all-single-step]"
 ]
 
+[project.scripts]
+syntheseus = "syntheseus.cli.main:main"
+
 [tool.setuptools.packages.find]
 # Guidance from: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
 where = ["."]

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -456,10 +456,10 @@ def run_from_config(
         extra_step(model, dataset, back_translation_model)
 
 
-def main(argv: Optional[List[str]]) -> None:
+def main(argv: Optional[List[str]] = None) -> None:
     config: EvalConfig = cli_get_config(argv=argv, config_cls=EvalConfig)
     run_from_config(config, extra_steps=[])
 
 
 if __name__ == "__main__":
-    main(argv=None)
+    main()

--- a/syntheseus/cli/main.py
+++ b/syntheseus/cli/main.py
@@ -1,0 +1,25 @@
+import sys
+
+from syntheseus.cli import eval_single_step, search
+
+
+def main() -> None:
+    supported_commands = {"search": search.main, "eval-single-step": eval_single_step.main}
+    supported_command_names = ", ".join(supported_commands.keys())
+
+    if len(sys.argv) == 1:
+        print(f"Please choose a command from: {supported_command_names}")
+        return
+
+    command = sys.argv[1]
+    if command not in supported_commands:
+        print(f"Command {command} not supported; choose from: {supported_command_names}")
+        return
+
+    # Drop the subcommand name and let the chosen command parse the rest of the arguments.
+    del sys.argv[1]
+    supported_commands[command]()
+
+
+if __name__ == "__main__":
+    main()

--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -309,7 +309,7 @@ def run_from_config(config: SearchConfig) -> Path:
     return results_dir_current_run
 
 
-def main(argv: Optional[List[str]]) -> Path:
+def main(argv: Optional[List[str]] = None) -> Path:
     config: SearchConfig = cli_get_config(argv=argv, config_cls=SearchConfig)
 
     def _warn_will_not_use_defaults(message: str) -> None:
@@ -352,4 +352,4 @@ def main(argv: Optional[List[str]]) -> Path:
 
 
 if __name__ == "__main__":
-    main(argv=None)
+    main()


### PR DESCRIPTION
Currently, the CLIs defined in `cli/` are not installed as part of the `pip`-based setup, so the only way to run them is to launch the script directly from source. This PR changes that by adding a top-level CLI endpoint, which then allows to select from `search` and `eval-single-step`.

Example usage after running `pip install -e .[all]`:
```
$ syntheseus
Please choose a command from: search, eval-single-step
$ syntheseus do-stuff
Command do-stuff not supported; choose from: search, eval-single-step
$ syntheseus eval-single-step model_class=LocalRetro model_dir=./local_retro/ data_dir=./uspto50k/
(...proceeds to run single-step evaluation...)
```