### PR TITLE
Return model predictions as dataclasses instead of pydantic models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Simplify single-step model setup ([#41](https://github.com/microsoft/syntheseus/pull/41)) ([@kmaziarz])
 - Refactor single-step evaluation script and move it to cli/ ([#43](https://github.com/microsoft/syntheseus/pull/43)) ([@kmaziarz])
+- Return model predictions as dataclasses instead of pydantic models ([#47](https://github.com/microsoft/syntheseus/pull/47)) ([@kmaziarz])
 
 ## [0.2.0] - 2023-11-21
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "networkx",             # search
     "numpy",                # reaction_prediction, search
     "omegaconf",            # reaction_prediction
-    "pydantic>=1.10.5,<2",  # reaction_prediction
     "rdkit",                # reaction_prediction, search
     "tqdm",                 # reaction_prediction
 ]

--- a/syntheseus/reaction_prediction/utils/misc.py
+++ b/syntheseus/reaction_prediction/utils/misc.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional
 import numpy as np
 
 from syntheseus.interface.bag import Bag
-from syntheseus.interface.models import Prediction, PredictionList
 from syntheseus.interface.molecule import Molecule
 
 
@@ -48,8 +47,6 @@ def dictify(data: Any) -> Any:
     elif isinstance(data, (List, tuple, Bag)):
         # Captures possible lists of `Prediction`s and lists of `PredictionList`s
         return [dictify(x) for x in data]
-    elif isinstance(data, (PredictionList, Prediction)):
-        return dictify(dict(data))
     elif isinstance(data, dict):
         return {k: dictify(v) for k, v in data.items()}
     elif is_dataclass(data):

--- a/syntheseus/tests/interface/test_models.py
+++ b/syntheseus/tests/interface/test_models.py
@@ -2,7 +2,7 @@ import math
 
 import numpy as np
 
-from syntheseus.interface.models import Prediction
+from syntheseus.interface.models import Prediction, PredictionList
 from syntheseus.interface.molecule import Molecule
 
 # TODO(kmaziarz): Currently this test mostly checks that importing from `models.py` works, and that
@@ -13,3 +13,11 @@ def test_prediction():
     prediction = Prediction(input=Molecule("C"), output=Molecule("CC"), probability=0.5)
     assert np.isclose(prediction.get_prob(), 0.5)
     assert np.isclose(prediction.get_log_prob(), math.log(0.5))
+
+    other_prediction = Prediction(input=Molecule("N"), output=Molecule("NC=O"), probability=0.5)
+    prediction_list = PredictionList(
+        input=Molecule("C"), predictions=[prediction, other_prediction]
+    )
+
+    assert prediction_list.predictions == [prediction, other_prediction]
+    assert prediction_list.truncated(num_results=1).predictions == [prediction]

--- a/syntheseus/tests/interface/test_models.py
+++ b/syntheseus/tests/interface/test_models.py
@@ -3,12 +3,13 @@ import math
 import numpy as np
 
 from syntheseus.interface.models import Prediction
+from syntheseus.interface.molecule import Molecule
 
 # TODO(kmaziarz): Currently this test mostly checks that importing from `models.py` works, and that
 # a `Prediction` object can be instantiated. We should extend it later.
 
 
 def test_prediction():
-    prediction = Prediction(probability=0.5)
+    prediction = Prediction(input=Molecule("C"), output=Molecule("CC"), probability=0.5)
     assert np.isclose(prediction.get_prob(), 0.5)
     assert np.isclose(prediction.get_log_prob(), math.log(0.5))

--- a/syntheseus/tests/reaction_prediction/utils/test_syntheseus_wrapper.py
+++ b/syntheseus/tests/reaction_prediction/utils/test_syntheseus_wrapper.py
@@ -20,7 +20,8 @@ class MockBackwardReactionModel(BackwardReactionModel):
         self, inputs: List[Molecule], num_results: int
     ) -> List[PredictionList[Molecule, Bag[Molecule]]]:
         return [
-            PredictionList(predictions=[Prediction(input=mol, output=Bag([mol]))]) for mol in inputs
+            PredictionList(input=mol, predictions=[Prediction(input=mol, output=Bag([mol]))])
+            for mol in inputs
         ]
 
     def get_parameters(self):


### PR DESCRIPTION
The `Prediction` and `PredictionList` objects were made based on `pydantic`, anticipating this will make it easier to e.g. expose a model through an API using a framework such as FastAPI. However, this meant introducing `pydantic` into the core of the library in order to facilitate a feature that most users may not care about. On the other hand, FastAPI can deal with non-`pydantic` classes too (`pydantic` is only needed for some extras like validation). Thus, once we want to integrate the server code properly, we should do it in such a way that `pydantic` (and further dependencies like `fastapi`) remain optional extras rather than part of the core of the library.

For now, in this PR I make the core prediction objects plain dataclasses, and drop `pydantic` from dependencies. This required a few changes (e.g. dropping special handling of prediction classes in `dictify`, using `default_factory` for the dict-valued fields), as well as fixing some of the tests, which did not provide all fields needed to construct the prediction objects (which for some reason is still accepted by `pydantic`).