### PR TITLE
Automatically download a default checkpoint if it is not provided

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -25,3 +25,6 @@ jobs:
     - name: Install syntheseus with all single-step models
       run: |
         pip install .[all]
+    - name: Run single-step model tests
+      run: |
+        python -m pytest ./syntheseus/tests/reaction_prediction/inference/test_models.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Add a general CLI endpoint ([#44](https://github.com/microsoft/syntheseus/pull/44)) ([@kmaziarz])
 - Add support for PDVN to the search CLI ([#46](https://github.com/microsoft/syntheseus/pull/46)) ([@fiberleif])
+- Add initial static documentation ([#45](https://github.com/microsoft/syntheseus/pull/45)) ([@kmaziarz])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Select search hyperparameters depending on which algorithm and single-step model are used ([#30](https://github.com/microsoft/syntheseus/pull/30)) ([@kmaziarz])
-- Add option to override time tolerance in algorithm tests ([#25](https://github.com/microsoft/syntheseus/pull/25)) ([@austint])
 - Improve the heuristic used for estimating diversity ([#22](https://github.com/microsoft/syntheseus/pull/22), [#28](https://github.com/microsoft/syntheseus/pull/28)) ([@kmaziarz])
-- Improve the aesthetics of `README.md` ([#19](https://github.com/microsoft/syntheseus/pull/19)) ([@kmaziarz])
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Simplify single-step model setup ([#41](https://github.com/microsoft/syntheseus/pull/41)) ([@kmaziarz])
+- Simplify single-step model setup ([#41](https://github.com/microsoft/syntheseus/pull/41), [#48](https://github.com/microsoft/syntheseus/pull/48)) ([@kmaziarz])
 - Refactor single-step evaluation script and move it to cli/ ([#43](https://github.com/microsoft/syntheseus/pull/43)) ([@kmaziarz])
 - Return model predictions as dataclasses instead of pydantic models ([#47](https://github.com/microsoft/syntheseus/pull/47)) ([@kmaziarz])
 

--- a/docs/single_step.md
+++ b/docs/single_step.md
@@ -4,10 +4,10 @@ Syntheseus currently supports 7 established single-step models. For convenience,
 |----------------------------------------------------------------|--------|
 | [Chemformer](https://figshare.com/ndownloader/files/42009888)  | finetuned by us starting from checkpoint released by authors |
 | [GLN](https://figshare.com/ndownloader/files/42012720)         | released by authors |
-| [LocalRetro](https://figshare.com/ndownloader/files/42012729)  | trained by us |
+| [LocalRetro](https://figshare.com/ndownloader/files/42287319)  | trained by us |
 | [MEGAN](https://figshare.com/ndownloader/files/42012732)       | trained by us |
 | [MHNreact](https://figshare.com/ndownloader/files/42012777)    | trained by us |
-| [RetroKNN](https://figshare.com/ndownloader/files/42012786)    | trained by us |
+| [RetroKNN](https://figshare.com/ndownloader/files/43636584)    | trained by us |
 | [RootAligned](https://figshare.com/ndownloader/files/42012792) | released by authors |
 
 ??? note "More advanced datasets"

--- a/docs/single_step.md
+++ b/docs/single_step.md
@@ -1,4 +1,9 @@
-Syntheseus currently supports 7 established single-step models. For convenience, for each model we also include a checkpoint trained on USPTO-50K.
+Syntheseus currently supports 7 established single-step models.
+
+For convenience, for each model we include a default checkpoint trained on USPTO-50K.
+If no checkpoint directory is provided during model loading, `syntheseus` will automatically download a default checkpoint and cache it on disk for future use.
+The default path for the cache is `$HOME/.cache/torch/syntheseus`, but it can be overriden by setting the `SYNTHESEUS_CACHE_DIR` environment variable.
+See table below for the links to the default checkpoints.
 
 | Model checkpoint link                                          | Source |
 |----------------------------------------------------------------|--------|

--- a/syntheseus/reaction_prediction/inference/base.py
+++ b/syntheseus/reaction_prediction/inference/base.py
@@ -15,10 +15,12 @@ class ExternalReactionModel(ReactionModel[InputType, OutputType]):
     """Base class for the external reaction models, abstracting out common functinality."""
 
     def __init__(
-        self, model_dir: Optional[Union[str, Path]] = None, device: str = "cuda:0"
+        self, model_dir: Optional[Union[str, Path]] = None, device: Optional[str] = None
     ) -> None:
+        import torch
+
         self.model_dir = Path(model_dir or self.get_default_model_dir())
-        self.device = device
+        self.device = device or ("cuda:0" if torch.cuda.is_available() else "cpu")
 
     def get_default_model_dir(self) -> Path:
         model_dir = get_default_model_dir_from_cache(self.name, is_forward=self.is_forward())

--- a/syntheseus/reaction_prediction/inference/base.py
+++ b/syntheseus/reaction_prediction/inference/base.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from typing import Optional, Union
+
+from syntheseus.interface.models import (
+    BackwardReactionModel,
+    ForwardReactionModel,
+    InputType,
+    OutputType,
+    ReactionModel,
+)
+from syntheseus.reaction_prediction.utils.downloading import get_default_model_dir_from_cache
+
+
+class ExternalReactionModel(ReactionModel[InputType, OutputType]):
+    """Base class for the external reaction models, abstracting out common functinality."""
+
+    def __init__(
+        self, model_dir: Optional[Union[str, Path]] = None, device: str = "cuda:0"
+    ) -> None:
+        self.model_dir = Path(model_dir or self.get_default_model_dir())
+        self.device = device
+
+    def get_default_model_dir(self) -> Path:
+        model_dir = get_default_model_dir_from_cache(self.name, is_forward=self.is_forward())
+
+        if model_dir is None:
+            raise ValueError(
+                f"Could not obtain a default checkpoint for model {self.name}, "
+                "please provide an explicit value for `model_dir`"
+            )
+
+        return model_dir
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__.removesuffix("Model")
+
+
+class ExternalBackwardReactionModel(ExternalReactionModel, BackwardReactionModel):
+    pass
+
+
+class ExternalForwardReactionModel(ExternalReactionModel, ForwardReactionModel):
+    pass

--- a/syntheseus/reaction_prediction/inference/default_checkpoint_links.yml
+++ b/syntheseus/reaction_prediction/inference/default_checkpoint_links.yml
@@ -1,0 +1,10 @@
+backward:
+  Chemformer: https://figshare.com/ndownloader/files/42009888
+  GLN: https://figshare.com/ndownloader/files/42012720
+  LocalRetro: https://figshare.com/ndownloader/files/42287319
+  MEGAN: https://figshare.com/ndownloader/files/42012732
+  MHNreact: https://figshare.com/ndownloader/files/42012777
+  RetroKNN: https://figshare.com/ndownloader/files/43636584
+  RootAligned: https://figshare.com/ndownloader/files/42012792
+forward:
+  Chemformer: https://figshare.com/ndownloader/files/42012708

--- a/syntheseus/reaction_prediction/inference/retro_knn.py
+++ b/syntheseus/reaction_prediction/inference/retro_knn.py
@@ -4,7 +4,7 @@ Paper: https://arxiv.org/abs/2306.04123
 """
 
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 
 import numpy as np
 
@@ -17,7 +17,7 @@ from syntheseus.reaction_prediction.utils.inference import get_unique_file_in_di
 class RetroKNNModel(LocalRetroModel):
     """Warpper for RetroKNN model."""
 
-    def __init__(self, model_dir: Union[str, Path], device: str = "cuda:0") -> None:
+    def __init__(self, model_dir: Optional[Union[str, Path]] = None, *args, **kwargs) -> None:
         """Initializes the RetroKNN model wrapper.
 
         Assumed format of the model directory:
@@ -25,11 +25,12 @@ class RetroKNNModel(LocalRetroModel):
         - `model_dir/knn/` contains the adapter checkpoint as the only `*.pt` file
         - `model_dir/knn/datastore` contains the data store files
         """
+        model_dir = Path(model_dir or self.get_default_model_dir())
+        super().__init__(model_dir / "local_retro", *args, **kwargs)
+
         import torch
 
         from syntheseus.reaction_prediction.models.retro_knn import Adapter
-
-        super().__init__(model_dir=Path(model_dir) / "local_retro", device=device)
 
         adapter_chkpt_path = get_unique_file_in_dir(Path(model_dir) / "knn", pattern="*.pt")
         datastore_path = Path(model_dir) / "knn" / "datastore"

--- a/syntheseus/reaction_prediction/utils/downloading.py
+++ b/syntheseus/reaction_prediction/utils/downloading.py
@@ -1,0 +1,74 @@
+import logging
+import os
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+logger = logging.getLogger(__file__)
+
+
+def get_cache_dir(key: str) -> Path:
+    """Get the cache directory for a given key (e.g. model name)."""
+
+    # First, check if the cache directory has been manually overriden.
+    cache_dir_from_env = os.getenv("SYNTHESEUS_CACHE_DIR")
+    if cache_dir_from_env is not None:
+        # If yes, use the path provided.
+        cache_dir = Path(cache_dir_from_env)
+    else:
+        # If not, construct a reasonable default.
+        cache_dir = Path(os.getenv("HOME", ".")) / ".cache" / "torch" / "syntheseus"
+
+    cache_dir = cache_dir / key
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    return cache_dir
+
+
+def get_cache_dir_download_if_missing(key: str, link: str) -> Path:
+    """Get the cache directory for a given key, but populate by downloading from link if empty."""
+
+    cache_dir = get_cache_dir(key)
+    if not any(cache_dir.iterdir()):
+        cache_zip_path = cache_dir / "model.zip"
+
+        logger.info(f"Downloading data from {link} to {cache_zip_path}")
+        urllib.request.urlretrieve(link, cache_zip_path)
+
+        with zipfile.ZipFile(cache_zip_path, "r") as f_zip:
+            f_zip.extractall(cache_dir)
+
+        cache_zip_path.unlink()
+
+    return cache_dir
+
+
+def get_default_model_dir_from_cache(model_name: str, is_forward: bool) -> Optional[Path]:
+    default_model_links_file_path = (
+        Path(__file__).parent.parent / "inference" / "default_checkpoint_links.yml"
+    )
+
+    if not default_model_links_file_path.exists():
+        logger.info(
+            f"Could not obtain a default model link: {default_model_links_file_path} does not exist"
+        )
+        return None
+
+    with open(default_model_links_file_path, "rt") as f_defaults:
+        default_model_links = yaml.safe_load(f_defaults)
+
+    assert default_model_links.keys() == {"backward", "forward"}
+
+    forward_backward_key = "forward" if is_forward else "backward"
+    model_links = default_model_links[forward_backward_key]
+
+    if model_name not in model_links:
+        logger.info(f"Could not obtain a default model link: no entry for {model_name}")
+        return None
+
+    return get_cache_dir_download_if_missing(
+        f"{model_name}_{forward_backward_key}", link=model_links[model_name]
+    )

--- a/syntheseus/tests/reaction_prediction/inference/test_models.py
+++ b/syntheseus/tests/reaction_prediction/inference/test_models.py
@@ -1,0 +1,63 @@
+import pytest
+
+from syntheseus.interface.bag import Bag
+from syntheseus.interface.molecule import Molecule
+from syntheseus.reaction_prediction.inference import ChemformerModel, LocalRetroModel, MEGANModel
+from syntheseus.reaction_prediction.inference.base import ExternalBackwardReactionModel
+
+try:
+    # Try to import the single-step model repositories to check if they are installed. Technically,
+    # it could be the case that these are installed but their dependencies are not, in which case
+    # the tests will fail; nevertheless the check below is good enough for our usecase.
+
+    import chemformer  # noqa: F401
+    import local_retro  # noqa: F401
+    import megan  # noqa: F401
+
+    MODELS_INSTALLED = True
+except ModuleNotFoundError:
+    MODELS_INSTALLED = False
+
+
+pytestmark = pytest.mark.skipif(
+    not MODELS_INSTALLED, reason="Model tests require all single-step models to be installed"
+)
+
+
+# TODO(kmaziarz): Some of the models (MHNreact, RetroKNN and RootAligned) appear to only work on
+# GPU. Make them also work on CPU, then add below.
+
+
+@pytest.fixture(
+    scope="module",
+    params=[ChemformerModel, LocalRetroModel, MEGANModel],
+)
+def model(request) -> ExternalBackwardReactionModel:
+    model_cls = request.param
+    return model_cls(device="cpu")
+
+
+def test_call(model: ExternalBackwardReactionModel) -> None:
+    [result] = model([Molecule("Cc1ccc(-c2ccc(C)cc2)cc1")], num_results=10)
+    model_predictions = [prediction.output for prediction in result.predictions]
+
+    # Prepare some coupling reactions that are reasonable predictions for the product above.
+    expected_predictions = [
+        Bag([Molecule(f"Cc1ccc({leaving_group_1})cc1"), Molecule(f"Cc1ccc({leaving_group_2})cc1")])
+        for leaving_group_1 in ["Br", "I"]
+        for leaving_group_2 in ["B(O)O", "I", "[Mg+]"]
+    ]
+
+    # The model should recover at least two (out of six) in its top-10.
+    assert len(set(expected_predictions) & set(model_predictions)) >= 2
+
+
+def test_misc(model: ExternalBackwardReactionModel) -> None:
+    import torch
+
+    assert isinstance(model.name, str)
+    assert isinstance(model.get_model_info(), dict)
+    assert model.is_backward() is not model.is_forward()
+
+    for p in model.get_parameters():
+        assert isinstance(p, torch.Tensor)

--- a/syntheseus/tests/reaction_prediction/inference/test_models.py
+++ b/syntheseus/tests/reaction_prediction/inference/test_models.py
@@ -34,7 +34,7 @@ pytestmark = pytest.mark.skipif(
 )
 def model(request) -> ExternalBackwardReactionModel:
     model_cls = request.param
-    return model_cls(device="cpu")
+    return model_cls()
 
 
 def test_call(model: ExternalBackwardReactionModel) -> None:


### PR DESCRIPTION
This PR extends the single-step model classes to automatically download the default (trained on USPTO-50K) model checkpoint if no model directory is provided. This makes it even easier to get started with `syntheseus` as one does not have to manually download and unzip the files. Once downloaded, the checkpoints are cached.

On top of this, I also extend the integration CI to run a new single-step model test that checks that the supported models do run and return reasonable predictions for a simple input. While locally the test works for all 6 `pip`-installable models, on GitHub the GPU is not available, and setting `device="cpu"` uncovers that some of the models appear to only work on GPU. Thus, for now the test only covers Chemformer, LocalRetro and MEGAN; the other models will be added in the future.

When running those tests, I found that the links we provided for LocalRetro and RetroKNN were not quite correct (the initial upload missed some of the files, which I later corrected, but the links were still pointing to the first upload rather than the corrected one). Morever, I found that RetroKNN was zipped using a method that `python` could not deal with, so I re-generated the file and re-uploaded it (again fixing the link).

The changes are separated into reasonable commits for easier reviewing.