### PR TITLE
Make the package compatible with PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Simplify single-step model setup ([#41](https://github.com/microsoft/syntheseus/pull/41), [#48](https://github.com/microsoft/syntheseus/pull/48)) ([@kmaziarz])
 - Refactor single-step evaluation script and move it to cli/ ([#43](https://github.com/microsoft/syntheseus/pull/43)) ([@kmaziarz])
 - Return model predictions as dataclasses instead of pydantic models ([#47](https://github.com/microsoft/syntheseus/pull/47)) ([@kmaziarz])
+- Make the package compatible with PyPI ([#50](https://github.com/microsoft/syntheseus/pull/50)) ([@kmaziarz])
 
 ## [0.2.0] - 2023-11-21
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <img src="docs/images/logo.png" height="50px">
+    <img src="https://github.com/microsoft/syntheseus/assets/61470923/f01a9939-61fa-4461-a124-c13eddcdd75a" height="50px">
     <h3><i>Navigating the labyrinth of synthesis planning</i></h3>
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 <figure markdown>
-  ![Image title](images/logo.png){width="450"}
+  ![Image title](https://github.com/microsoft/syntheseus/assets/61470923/f01a9939-61fa-4461-a124-c13eddcdd75a){width="450"}
   <figcaption><h3>Navigating the labyrinth of synthesis planning</h3></figcaption>
 </figure>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,10 @@ all = [
   "syntheseus[viz,dev,all-single-step]"
 ]
 
+[project.urls]
+Documentation = "https://microsoft.github.io/syntheseus"
+Repository = "https://github.com/microsoft/syntheseus"
+
 [project.scripts]
 syntheseus = "syntheseus.cli.main:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,25 +34,12 @@ dev = [
   "pytest-cov",
   "pre-commit"
 ]
-chemformer = [
-  "chemformer @ git+https://github.com/kmaziarz/Chemformer.git"
-]
-local-retro = [
-  "local_retro @ git+https://github.com/kmaziarz/LocalRetro.git"
-]
-megan = [
-  "megan @ git+https://github.com/kmaziarz/megan.git"
-]
-mhn-react = [
-  "mhnreact @ git+https://github.com/kmaziarz/mhn-react.git"
-]
-retro-knn = [
-  "local_retro @ git+https://github.com/kmaziarz/LocalRetro.git",
-  "torch-scatter"
-]
-root-aligned = [
-  "root_aligned @ git+https://github.com/kmaziarz/RootAligned.git"
-]
+chemformer = ["syntheseus-chemformer"]
+local-retro = ["syntheseus-local-retro"]
+megan = ["syntheseus-megan"]
+mhn-react = ["syntheseus-mhnreact"]
+retro-knn = ["syntheseus-local-retro", "torch-scatter"]
+root-aligned = ["syntheseus-root-aligned"]
 all-single-step = [
   "syntheseus[chemformer,local-retro,megan,mhn-react,retro-knn,root-aligned]"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "syntheseus"
-authors = [
-    {name = "Austin Tripp", email = "ajt212@cam.ac.uk"},
-    {name = "Krzysztof Maziarz", email = "krzysztof.maziarz@microsoft.com"},
-    {name = "Megan Stanley", email = "meganstanley@microsoft.com"},
-    {name = "Marwin Segler", email = "marwinsegler@microsoft.com"},
+authors = [  # Note: PyPI does not support multiple authors with email addresses included.
+    {name = "Austin Tripp"},       # ajt212@cam.ac.uk
+    {name = "Krzysztof Maziarz"},  # krzysztof.maziarz@microsoft.com
+    {name = "Guoqing Liu"},        # guoqingliu@microsoft.com
+    {name = "Megan Stanley"},      # meganstanley@microsoft.com
+    {name = "Marwin Segler"},      # marwinsegler@microsoft.com
 ]
 description = "A package for retrosynthetic planning."
 readme = "README.md"


### PR DESCRIPTION
This PR makes the `syntheseus` package work correctly on PyPI, which required several small changes:
- Using an absolute link for the logo, as otherwise it won't render in the PyPI package description.
- Adding project links to give PyPI access to GitHub's metadata.
- Switching to getting the single-step model code from auxiliary PyPI uploads instead of GitHub (PyPI doesn't allow the latter).
- Removing author email addresses, as PyPI cannot handle them in the case of multiple authors (and, while I was at it, also adding @fiberleif).