### PR TITLE
Switch LICENSE badge in the README to an absolute link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![CI](https://github.com/microsoft/syntheseus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/microsoft/syntheseus/actions/workflows/ci.yml)
 [![Python Version](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/)
 [![code style](https://img.shields.io/badge/code%20style-black-202020.svg)](https://github.com/ambv/black)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/microsoft/syntheseus/blob/main/LICENSE)
 
 Syntheseus is a package for end-to-end retrosynthetic planning.
 - ⚒️ Combines search algorithms and reaction models in a standardized way


### PR DESCRIPTION
Following #50, one additional change that was missed was switching the license link in the README to be absolute instead of relative, as the latter does not work in the PyPI package description.