### PR TITLE
Make single-step models less noisy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,18 +13,18 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [0.3.0] - 2023-12-19
 
-### Added
-
-- Add a general CLI endpoint ([#44](https://github.com/microsoft/syntheseus/pull/44)) ([@kmaziarz])
-- Add support for PDVN to the search CLI ([#46](https://github.com/microsoft/syntheseus/pull/46)) ([@fiberleif])
-- Add initial static documentation ([#45](https://github.com/microsoft/syntheseus/pull/45)) ([@kmaziarz])
-
 ### Changed
 
 - Simplify single-step model setup ([#41](https://github.com/microsoft/syntheseus/pull/41), [#48](https://github.com/microsoft/syntheseus/pull/48)) ([@kmaziarz])
 - Refactor single-step evaluation script and move it to cli/ ([#43](https://github.com/microsoft/syntheseus/pull/43)) ([@kmaziarz])
 - Return model predictions as dataclasses instead of pydantic models ([#47](https://github.com/microsoft/syntheseus/pull/47)) ([@kmaziarz])
 - Make the package compatible with PyPI ([#50](https://github.com/microsoft/syntheseus/pull/50)) ([@kmaziarz])
+
+### Added
+
+- Add a general CLI endpoint ([#44](https://github.com/microsoft/syntheseus/pull/44)) ([@kmaziarz])
+- Add support for PDVN to the search CLI ([#46](https://github.com/microsoft/syntheseus/pull/46)) ([@fiberleif])
+- Add initial static documentation ([#45](https://github.com/microsoft/syntheseus/pull/45)) ([@kmaziarz])
 
 ## [0.2.0] - 2023-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
+
 ## [0.3.0] - 2023-12-19
 
 ### Added

--- a/syntheseus/reaction_prediction/inference/chemformer.py
+++ b/syntheseus/reaction_prediction/inference/chemformer.py
@@ -7,6 +7,7 @@ The original Chemformer code is released under the Apache 2.0 license.
 """
 
 import sys
+import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, cast
 
@@ -117,7 +118,10 @@ class ChemformerModel(ExternalReactionModel[InputType, OutputType]):
 
         # We have to set `num_beams` as an attribute of the model.
         self.model.num_beams = num_results
-        with torch.no_grad():
+
+        with torch.no_grad(), warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="__floordiv__ is deprecated")
+
             smiles_batch, batch_log_likelihoods = self.model.sample_molecules(
                 device_batch, sampling_alg="beam"
             )

--- a/syntheseus/reaction_prediction/inference/megan.py
+++ b/syntheseus/reaction_prediction/inference/megan.py
@@ -44,6 +44,9 @@ class MEGANModel(ExternalBackwardReactionModel):
         """
         super().__init__(*args, **kwargs)
 
+        # Silence tensorflow's warnings.
+        os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+
         import gin
         import megan
 

--- a/syntheseus/reaction_prediction/inference/root_aligned.py
+++ b/syntheseus/reaction_prediction/inference/root_aligned.py
@@ -25,7 +25,6 @@ from syntheseus.reaction_prediction.utils.inference import (
     get_unique_file_in_dir,
     process_raw_smiles_outputs,
 )
-from syntheseus.reaction_prediction.utils.misc import suppress_outputs
 
 
 class RootAlignedModel(ExternalBackwardReactionModel):
@@ -61,15 +60,11 @@ class RootAlignedModel(ExternalBackwardReactionModel):
 
         # Import external functions from `root_aligned/OpenNMT.py`.
         from onmt.translate.translator import build_translator
-        from onmt.utils.logging import init_logger
         from onmt.utils.parse import ArgumentParser
 
         ArgumentParser.validate_translate_opts(opt)
 
-        with suppress_outputs():
-            logger = init_logger(opt.log_file)
-
-        self.translator = build_translator(opt, logger=logger, report_score=True)
+        self.translator = build_translator(opt, report_score=False)
         self.num_augmentations = num_augmentations
         self.probability_from_score_temperature = probability_from_score_temperature
         self.beam_size = opt.beam_size

--- a/syntheseus/reaction_prediction/inference/root_aligned.py
+++ b/syntheseus/reaction_prediction/inference/root_aligned.py
@@ -11,6 +11,7 @@ import argparse
 import math
 import multiprocessing
 import random
+import warnings
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
@@ -187,15 +188,18 @@ class RootAlignedModel(ExternalBackwardReactionModel):
         augmented_batch = self._mols_to_batch(augmented_inputs)
 
         # Step 3: Translate.
-        _, augmented_predictions = self.translator.translate(
-            src=augmented_batch,
-            src_feats=defaultdict(list),
-            tgt=None,
-            batch_size=2048,
-            batch_type="tokens",
-            attn_debug=False,
-            align_debug=False,
-        )  # shape: `[data_size x augmentation_size, beam_size]`
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="__floordiv__ is deprecated")
+
+            _, augmented_predictions = self.translator.translate(
+                src=augmented_batch,
+                src_feats=defaultdict(list),
+                tgt=None,
+                batch_size=2048,
+                batch_type="tokens",
+                attn_debug=False,
+                align_debug=False,
+            )  # shape: `[data_size x augmentation_size, beam_size]`
 
         # Step 4: Unravel and canonicalize.
         lines = []  # shape: `[data_size x augmentation_size x beam_size]`

--- a/syntheseus/reaction_prediction/utils/misc.py
+++ b/syntheseus/reaction_prediction/utils/misc.py
@@ -33,8 +33,13 @@ def suppress_outputs():
     """Suppress messages written to both stdout and stderr."""
     with open(devnull, "w") as fnull:
         with redirect_stderr(fnull), redirect_stdout(fnull):
+            # Save the root logger handlers in order to restore them afterwards.
+            root_handlers = list(logging.root.handlers)
             logging.disable(logging.CRITICAL)
+
             yield
+
+            logging.root.handlers = root_handlers
             logging.disable(logging.NOTSET)
 
 


### PR DESCRIPTION
This PR combines a sequence of changes to make the single-step models less noisy. This involves silencing benign warnings originating from PyTorch, turning off logging produced by tensorflow and OpenNMT, and also making sure the underlying model code doesn't tamper with root logger handlers or create log files. With these changes, creating and using any of the models should be now free of confusing logging/warning messages.