### PR TITLE
Add a "Quick Start" tutorial

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,5 +27,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocs-jupyter
       - run: mkdocs gh-deploy --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
 
+### Added
+
+- Add a new tutorial employing non-toy single-step models ([#54](https://github.com/microsoft/syntheseus/pull/54)) ([@kmaziarz])
+
 ## [0.3.0] - 2023-12-19
 
 ### Changed

--- a/docs/tutorials/quick_start.ipynb
+++ b/docs/tutorials/quick_start.ipynb
@@ -272,8 +272,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Route 1 consists of 6 reactions\n",
-      "Route 2 consists of 8 reactions\n"
+      "Route 1 consists of 2 reactions\n",
+      "Route 2 consists of 3 reactions\n"
      ]
     }
    ],
@@ -281,12 +281,14 @@
     "from syntheseus.search.analysis.route_extraction import (\n",
     "    iter_routes_time_order,\n",
     ")\n",
+    "from syntheseus.search.graph.and_or import AndNode\n",
     "\n",
     "# Extract the routes simply in the order they were found.\n",
     "routes = list(iter_routes_time_order(output_graph, max_routes=10))\n",
     "\n",
     "for idx, route in enumerate(routes):\n",
-    "    print(f\"Route {idx + 1} consists of {len(route)} reactions\")"
+    "    num_reactions = len({n for n in route if isinstance(n, AndNode)})\n",
+    "    print(f\"Route {idx + 1} consists of {num_reactions} reactions\")"
    ]
   },
   {
@@ -305,7 +307,9 @@
     "from syntheseus.search.visualization import visualize_andor\n",
     "\n",
     "for idx, route in enumerate(routes):\n",
-    "    visualize_andor(output_graph, filename=f\"route_{idx + 1}.pdf\", nodes=route)"
+    "    visualize_andor(\n",
+    "        output_graph, filename=f\"route_{idx + 1}.pdf\", nodes=route\n",
+    "    )"
    ]
   },
   {

--- a/docs/tutorials/quick_start.ipynb
+++ b/docs/tutorials/quick_start.ipynb
@@ -1,0 +1,343 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting up a single-step model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's start by creating a test molecule and querying LocalRetro for proposed reactions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from syntheseus.interface.molecule import Molecule\n",
+    "from syntheseus.reaction_prediction.inference import LocalRetroModel\n",
+    "\n",
+    "test_mol = Molecule(\"Cc1ccc(-c2ccc(C)cc2)cc1\")\n",
+    "model = LocalRetroModel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we didn't provide a path to the model checkpoint, so `syntheseus` will download a default checkpoint trained on USPTO-50K and cache it for later use. This behaviour can be overriden by providing a `model_dir` argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/krmaziar/.cache/torch/syntheseus/LocalRetro_backward\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(model.model_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's print the top 5 predictions for our test molecule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1: Cc1ccc(B(O)O)cc1 + Cc1ccc(Br)cc1\n",
+      "2: Cc1ccc(B(O)O)cc1 + Cc1ccc(I)cc1\n",
+      "3: Cc1ccc(B(O)O)cc1 + Cc1ccc(Br)cc1\n",
+      "4: Cc1ccc(B(O)O)cc1 + Cc1ccc(I)cc1\n",
+      "5: Cc1ccc(Br)cc1 + Cc1ccc([Mg+])cc1\n"
+     ]
+    }
+   ],
+   "source": [
+    "def mols_to_str(mols) -> str:\n",
+    "    return \" + \".join([mol.smiles for mol in mols])\n",
+    "\n",
+    "def print_results(results) -> None:\n",
+    "    for idx, prediction in enumerate(results.predictions):\n",
+    "        print(f\"{idx + 1}: \" + mols_to_str(prediction.output))\n",
+    "\n",
+    "[results] = model([test_mol], num_results=5)\n",
+    "print_results(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The outputs from the underlying model contain duplicates. We can use a higher-level utility function to get unique outputs as well as timing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1: Cc1ccc(B(O)O)cc1 + Cc1ccc(Br)cc1\n",
+      "2: Cc1ccc(B(O)O)cc1 + Cc1ccc(I)cc1\n",
+      "3: Cc1ccc(Br)cc1 + Cc1ccc([Mg+])cc1\n",
+      "\n",
+      "Time taken by model call: 0.04s\n"
+     ]
+    }
+   ],
+   "source": [
+    "from syntheseus.cli.eval_single_step import get_results\n",
+    "\n",
+    "results_with_timing = get_results(\n",
+    "    model, inputs=[test_mol], num_results=5, measure_time=True\n",
+    ")\n",
+    "\n",
+    "print_results(results_with_timing.results[0])\n",
+    "\n",
+    "time_taken = results_with_timing.model_timing_results.time_model_call\n",
+    "print(f\"\\nTime taken by model call: {time_taken:.2f}s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As `syntheseus` sets up all single-step models in a consistent way, it's easy to run several models and compare their outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chemformer:  Cc1ccc(Br)cc1 + Cc1ccc(Br)cc1\n",
+      "LocalRetro:  Cc1ccc(B(O)O)cc1 + Cc1ccc(Br)cc1\n",
+      "MEGAN:       Cc1ccc(Br)cc1 + Cc1ccc([Mg+])cc1\n",
+      "MHNreact:    Cc1ccc(Br)cc1 + Cc1ccc([Mg+])cc1\n",
+      "RetroKNN:    Cc1ccc(B(O)O)cc1 + Cc1ccc(Br)cc1\n",
+      "RootAligned: Cc1ccc(Br)cc1 + Cc1ccc([Mg+])cc1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from syntheseus.reaction_prediction.inference import *\n",
+    "\n",
+    "models = [\n",
+    "    ChemformerModel(),\n",
+    "    LocalRetroModel(),\n",
+    "    MEGANModel(),\n",
+    "    MHNreactModel(),\n",
+    "    RetroKNNModel(),\n",
+    "    RootAlignedModel(),\n",
+    "]\n",
+    "\n",
+    "for model in models:\n",
+    "    # When interested in very few predictions (e.g. one), it may be\n",
+    "    # useful to set `num_results > 1`, as this will cause e.g.\n",
+    "    # larger beam size for models based on beam search.\n",
+    "    [results] = get_results(model, [test_mol], num_results=5).results\n",
+    "\n",
+    "    top_prediction = results.predictions[0].output\n",
+    "    print(f\"{model.name + ':':12} {mols_to_str(top_prediction)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running search"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run multi-step search we need three things:\n",
+    "- a reaction model\n",
+    "- an inventory of purchasable (building block) molecules\n",
+    "- a search algorithm\n",
+    "\n",
+    "We can use any of the single-step models shown above, but they need to be wrapped to make them usable in search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from syntheseus.reaction_prediction.utils.syntheseus_wrapper import (\n",
+    "    SyntheseusBackwardReactionModel,\n",
+    ")\n",
+    "\n",
+    "search_model = SyntheseusBackwardReactionModel(\n",
+    "    model=LocalRetroModel(), num_results=10\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from syntheseus.search.mol_inventory import SmilesListInventory\n",
+    "from syntheseus.search.algorithms.breadth_first import (\n",
+    "    AndOr_BreadthFirstSearch\n",
+    ")\n",
+    "\n",
+    "# Dummy inventory with just two purchasable molecules.\n",
+    "inventory = SmilesListInventory(\n",
+    "    smiles_list=[\"Cc1ccc(B(O)O)cc1\", \"O=Cc1ccc(I)cc1\"]\n",
+    ")\n",
+    "\n",
+    "search_algorithm = AndOr_BreadthFirstSearch(\n",
+    "    reaction_model=search_model,\n",
+    "    mol_inventory=inventory,\n",
+    "    limit_iterations=100,  # max number of algorithm iterations\n",
+    "    limit_reaction_model_calls=100,  # max number of model calls\n",
+    "    time_limit_s=60.0  # max runtime in seconds\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_graph, _ = search_algorithm.run_from_mol(test_mol)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Explored 1256 nodes\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Explored {len(output_graph)} nodes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The resulting graph contains all the explored molecules and reactions, some of which might have led to complete routes while others remained unsolved. From that we can extract complete routes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Route 1 consists of 6 reactions\n",
+      "Route 2 consists of 8 reactions\n"
+     ]
+    }
+   ],
+   "source": [
+    "from syntheseus.search.analysis.route_extraction import (\n",
+    "    iter_routes_time_order,\n",
+    ")\n",
+    "\n",
+    "# Extract the routes simply in the order they were found.\n",
+    "routes = list(iter_routes_time_order(output_graph, max_routes=10))\n",
+    "\n",
+    "for idx, route in enumerate(routes):\n",
+    "    print(f\"Route {idx + 1} consists of {len(route)} reactions\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use visualization utilities to get a quick look at the routes found."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from syntheseus.search.visualization import visualize_andor\n",
+    "\n",
+    "for idx, route in enumerate(routes):\n",
+    "    visualize_andor(output_graph, filename=f\"route_{idx + 1}.pdf\", nodes=route)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The contents of the files `route_{1, 2}.pdf` should look roughly like the below.\n",
+    "\n",
+    "<img align=\"top\" src=\"https://github.com/microsoft/syntheseus/assets/61470923/f3d93324-9920-43b1-9d61-a4386e20a654\" width=\"320px\">\n",
+    "<img align=\"top\" src=\"https://github.com/microsoft/syntheseus/assets/61470923/e12489b4-e129-4d7e-822f-75da5aaf7af5\" width=\"320px\">"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "syntheseus-single-step",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,11 @@ nav:
   - Single-Step Models: single_step.md
 - CLI:
   - Single-Step Evaluation: cli/eval_single_step.md
+- Tutorials:
+  - Quick Start: tutorials/quick_start.ipynb
+
+plugins:
+  - mkdocs-jupyter
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
This PR adds a new tutorial, which is a runnable jupyter notebook while also being integrated into the docs. The idea is for these new tutorials to eventually supersede the old ones which currently live under `tutorials/`. Unlike the latter (which predate full integration between single-step and multi-step code), the tutorial added here uses real single-step models as opposed to toy ones, as well as realistic molecules/reactions.