### PR TITLE
Mention installation from PyPI in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Add a new tutorial employing non-toy single-step models ([#54](https://github.com/microsoft/syntheseus/pull/54)) ([@kmaziarz])
 
+### Fixed
+
+- Get all single-step models to work on CPU ([#57](https://github.com/microsoft/syntheseus/pull/57)) ([@kmaziarz])
+
 ## [0.3.0] - 2023-12-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 [![CI](https://github.com/microsoft/syntheseus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/microsoft/syntheseus/actions/workflows/ci.yml)
 [![Python Version](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/)
+[![pypi](https://img.shields.io/pypi/v/syntheseus.svg)](https://pypi.org/project/syntheseus/)
 [![code style](https://img.shields.io/badge/code%20style-black-202020.svg)](https://github.com/ambv/black)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/microsoft/syntheseus/blob/main/LICENSE)
 
@@ -27,7 +28,7 @@ To install `syntheseus` with all the extras, run
 conda env create -f environment_full.yml
 conda activate syntheseus-full
 
-pip install -e ".[all]"
+pip install "syntheseus[all]"
 ```
 
 See [documentation](https://microsoft.github.io/syntheseus/installation) if you prefer a more lightweight installation that only includes the parts you actually need.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@
 
 [![CI](https://github.com/microsoft/syntheseus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/microsoft/syntheseus/actions/workflows/ci.yml)
 [![Python Version](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/)
+[![pypi](https://img.shields.io/pypi/v/syntheseus.svg)](https://pypi.org/project/syntheseus/)
 [![code style](https://img.shields.io/badge/code%20style-black-202020.svg)](https://github.com/ambv/black)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/microsoft/syntheseus/blob/main/LICENSE)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,25 @@ We support two installation modes:
 - *core installation* allows you to build and benchmark your own models or search algorithms
 - *full installation* also allows you to perform end-to-end search using the supported models
 
-=== "Core installation"
+=== "Core (pip)"
+
+    ```bash
+    conda env create -f environment.yml
+    conda activate syntheseus
+
+    pip install syntheseus
+    ```
+
+=== "Full (pip)"
+
+    ```bash
+    conda env create -f environment_full.yml
+    conda activate syntheseus-full
+
+    pip install "syntheseus[all]"
+    ```
+
+=== "Core (source)"
 
     ```bash
     conda env create -f environment.yml
@@ -12,7 +30,7 @@ We support two installation modes:
     pip install -e .
     ```
 
-=== "Full installation"
+=== "Full (source)"
 
     ```bash
     conda env create -f environment_full.yml


### PR DESCRIPTION
This small PR mentions installation from PyPI in the docs and README, and also adds a shields.io badge showing the latest version.