### PR TITLE
Remove PredictionList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
-- Removed PredictionList objects, replacing them with Sequence[Prediction] ([#60](https://github.com/microsoft/syntheseus/pull/60)) ([@austint])
+- Remove `PredictionList` objects, replacing them with `Sequence[Prediction]` ([#61](https://github.com/microsoft/syntheseus/pull/61)) ([@austint])
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
+- Removed PredictionList objects, replacing them with Sequence[Prediction] ([#60](https://github.com/microsoft/syntheseus/pull/60)) ([@austint])
 
 ### Added
 

--- a/docs/tutorials/quick_start.ipynb
+++ b/docs/tutorials/quick_start.ipynb
@@ -80,7 +80,7 @@
     "    return \" + \".join([mol.smiles for mol in mols])\n",
     "\n",
     "def print_results(results) -> None:\n",
-    "    for idx, prediction in enumerate(results.predictions):\n",
+    "    for idx, prediction in enumerate(results):\n",
     "        print(f\"{idx + 1}: \" + mols_to_str(prediction.output))\n",
     "\n",
     "[results] = model([test_mol], num_results=5)\n",
@@ -167,7 +167,7 @@
     "    # larger beam size for models based on beam search.\n",
     "    [results] = get_results(model, [test_mol], num_results=5).results\n",
     "\n",
-    "    top_prediction = results.predictions[0].output\n",
+    "    top_prediction = results[0].output\n",
     "    print(f\"{model.name + ':':12} {mols_to_str(top_prediction)}\")"
    ]
   },

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -18,12 +18,11 @@ import logging
 import math
 import os
 import time
-from collections.abc import Sequence
 from dataclasses import dataclass, field, fields
 from functools import partial
 from itertools import islice
 from statistics import mean, median
-from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Set, cast
+from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Sequence, Set, cast
 
 from more_itertools import batched
 from omegaconf import MISSING, OmegaConf

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -18,6 +18,7 @@ import logging
 import math
 import os
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass, field, fields
 from functools import partial
 from itertools import islice
@@ -33,7 +34,6 @@ from syntheseus.interface.models import (
     InputType,
     OutputType,
     Prediction,
-    PredictionList,
     ReactionModel,
 )
 from syntheseus.interface.molecule import Molecule
@@ -91,7 +91,7 @@ class EvalConfig(BackwardModelConfig, BaseEvalConfig):
 
 @dataclass(frozen=True)
 class ModelResults(Generic[InputType, OutputType]):
-    results: List[PredictionList[InputType, OutputType]]
+    results: List[Sequence[Prediction[InputType, OutputType]]]
     model_timing_results: Optional[ModelTimingResults] = None
 
 
@@ -111,8 +111,8 @@ class EvalResults:
     model_time_total: ModelTimingResults
     back_translation_top_k: Optional[List[float]] = None
     back_translation_mrr: Optional[float] = None
-    predictions: Optional[List[PredictionList]] = None
-    back_translation_predictions: Optional[List[List[PredictionList]]] = None
+    predictions: Optional[List[Sequence[Prediction]]] = None
+    back_translation_predictions: Optional[List[List[Sequence[Prediction]]]] = None
     back_translation_time_total: Optional[ModelTimingResults] = None
 
 
@@ -158,18 +158,16 @@ def get_results(
         time_model_call_end = time.time()
         timing_results["time_model_call"] = time_model_call_end - time_model_call_start
 
-    batch_outputs: List[PredictionList[InputType, OutputType]] = []
+    batch_outputs: List[Sequence[Prediction[InputType, OutputType]]] = []
 
     for outputs in raw_batch_outputs:
-        if len(outputs.predictions) > num_results:
-            raise ValueError(
-                f"Requested {num_results} results, but model produced {len(outputs.predictions)}"
-            )
+        if len(outputs) > num_results:
+            raise ValueError(f"Requested {num_results} results, but model produced {len(outputs)}")
 
         seen_outputs: Set[OutputType] = set()
         selected_predictions: List[Prediction[InputType, OutputType]] = []
 
-        for prediction in outputs.predictions:
+        for prediction in outputs:
             if skip_repeats:
                 if prediction.output in seen_outputs:
                     continue
@@ -182,11 +180,7 @@ def get_results(
                 f"Tried to get {num_results} results, but only got {len(selected_predictions)}"
             )
 
-        batch_outputs.append(
-            PredictionList(
-                input=outputs.input, predictions=selected_predictions, metadata=outputs.metadata
-            )
-        )
+        batch_outputs.append(list(selected_predictions))
 
     if measure_time:
         timing_results["time_post_processing"] = time.time() - time_model_call_end
@@ -238,8 +232,8 @@ def compute_metrics(
 
     print(f"Testing model {model.__class__.__name__} with args {eval_args}")
 
-    all_predictions: List[PredictionList] = []
-    all_back_translation_predictions: List[List[PredictionList]] = []
+    all_predictions: List[Sequence[Prediction]] = []
+    all_back_translation_predictions: List[List[Sequence[Prediction]]] = []
 
     model_timing_results: List[ModelTimingResults] = []
     back_translation_timing_results: List[ModelTimingResults] = []
@@ -289,20 +283,18 @@ def compute_metrics(
         assert results_with_timing.model_timing_results is not None
         model_timing_results.append(results_with_timing.model_timing_results)
 
-        batch_predictions: List[PredictionList[InputType, OutputType]] = results_with_timing.results
+        batch_predictions: List[
+            Sequence[Prediction[InputType, OutputType]]
+        ] = results_with_timing.results
 
-        batch_back_translation_predictions: List[List[PredictionList]] = []
+        batch_back_translation_predictions: List[List[Sequence[Prediction]]] = []
         for input, output, prediction_list in zip(inputs, outputs, batch_predictions):
-            num_predictions.append(len(prediction_list.predictions))
+            num_predictions.append(len(prediction_list))
 
-            ground_truth_matches = [
-                prediction.output == output for prediction in prediction_list.predictions
-            ]
+            ground_truth_matches = [prediction.output == output for prediction in prediction_list]
             ground_truth_match_metrics.add(ground_truth_matches)
 
-            for prediction, ground_truth_match in zip(
-                prediction_list.predictions, ground_truth_matches
-            ):
+            for prediction, ground_truth_match in zip(prediction_list, ground_truth_matches):
                 prediction.metadata["ground_truth_match"] = ground_truth_match
 
             if back_translation_model is not None:
@@ -310,7 +302,7 @@ def compute_metrics(
 
                 back_translation_results_with_timing = get_results(
                     back_translation_model,
-                    [prediction.output for prediction in prediction_list.predictions],
+                    [prediction.output for prediction in prediction_list],
                     num_results=back_translation_num_results,
                     skip_repeats=False,
                     measure_time=True,
@@ -329,10 +321,7 @@ def compute_metrics(
                 # Back translation is successful if any of the `back_translation_num_results` bags
                 # of products returned by the forward model contains the input.
                 back_translation_matches = [
-                    any(
-                        input in cast(Bag[Molecule], prediction.output)
-                        for prediction in result.predictions
-                    )
+                    any(input in cast(Bag[Molecule], prediction.output) for prediction in result)
                     for result in back_translation_results
                 ]
 

--- a/syntheseus/interface/models.py
+++ b/syntheseus/interface/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from abc import abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Dict, Generic, List, Optional, TypeVar
 
@@ -53,29 +54,13 @@ class Prediction(Generic[InputType, OutputType]):
             raise ValueError("Prediction does not have associated log prob or probability value.")
 
 
-@dataclass(frozen=True, order=False)
-class PredictionList(Generic[InputType, OutputType]):
-    """Several possible predictions."""
-
-    input: InputType
-    predictions: List[Prediction[InputType, OutputType]]
-
-    # Dictionary to hold additional metadata.
-    metadata: Dict[str, Any] = field(default_factory=dict)
-
-    def truncated(self, num_results: int) -> PredictionList[InputType, OutputType]:
-        return PredictionList(
-            input=self.input, predictions=self.predictions[:num_results], metadata=self.metadata
-        )
-
-
 class ReactionModel(Generic[InputType, OutputType]):
     """Base class for all reaction models, both backward and forward."""
 
     @abstractmethod
     def __call__(
         self, inputs: List[InputType], num_results: int
-    ) -> List[PredictionList[InputType, OutputType]]:
+    ) -> List[Sequence[Prediction[InputType, OutputType]]]:
         """Given a batch of inputs to the reaction model, return a batch of results.
 
         Args:
@@ -122,6 +107,3 @@ class ForwardReactionModel(ReactionModel[Bag[Molecule], Bag[Molecule]]):
 
 BackwardPrediction = Prediction[Molecule, Bag[Molecule]]
 ForwardPrediction = Prediction[Bag[Molecule], Bag[Molecule]]
-
-BackwardPredictionList = PredictionList[Molecule, Bag[Molecule]]
-ForwardPredictionList = PredictionList[Bag[Molecule], Bag[Molecule]]

--- a/syntheseus/interface/models.py
+++ b/syntheseus/interface/models.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import math
 from abc import abstractmethod
-from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, Dict, Generic, List, Optional, TypeVar
+from typing import Any, Dict, Generic, List, Optional, Sequence, TypeVar
 
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.molecule import Molecule

--- a/syntheseus/reaction_prediction/inference/chemformer.py
+++ b/syntheseus/reaction_prediction/inference/chemformer.py
@@ -8,11 +8,12 @@ The original Chemformer code is released under the Apache 2.0 license.
 
 import sys
 import warnings
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, cast
 
 from syntheseus.interface.bag import Bag
-from syntheseus.interface.models import InputType, OutputType, PredictionList
+from syntheseus.interface.models import InputType, OutputType, Prediction
 from syntheseus.interface.molecule import Molecule
 from syntheseus.reaction_prediction.inference.base import ExternalReactionModel
 from syntheseus.reaction_prediction.utils.inference import (
@@ -105,7 +106,9 @@ class ChemformerModel(ExternalReactionModel[InputType, OutputType]):
             "encoder_pad_mask": torch.tensor(mask, dtype=torch.bool).transpose(0, 1),
         }
 
-    def __call__(self, inputs: List[InputType], num_results: int) -> List[PredictionList]:
+    def __call__(
+        self, inputs: List[InputType], num_results: int
+    ) -> List[Sequence[Prediction[InputType, OutputType]]]:
         import torch
 
         # Get the data in to the right form to call the sampling method on the model.

--- a/syntheseus/reaction_prediction/inference/chemformer.py
+++ b/syntheseus/reaction_prediction/inference/chemformer.py
@@ -8,9 +8,8 @@ The original Chemformer code is released under the Apache 2.0 license.
 
 import sys
 import warnings
-from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, cast
+from typing import Any, Dict, List, Sequence, Tuple, cast
 
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.models import InputType, OutputType, Prediction

--- a/syntheseus/reaction_prediction/inference/gln.py
+++ b/syntheseus/reaction_prediction/inference/gln.py
@@ -7,9 +7,8 @@ The original GLN code is released under the MIT license.
 """
 
 import sys
-from collections.abc import Sequence
 from pathlib import Path
-from typing import List
+from typing import List, Sequence
 
 from syntheseus.interface.models import BackwardPrediction
 from syntheseus.interface.molecule import Molecule

--- a/syntheseus/reaction_prediction/inference/gln.py
+++ b/syntheseus/reaction_prediction/inference/gln.py
@@ -7,10 +7,11 @@ The original GLN code is released under the MIT license.
 """
 
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 from typing import List
 
-from syntheseus.interface.models import BackwardPredictionList
+from syntheseus.interface.models import BackwardPrediction
 from syntheseus.interface.molecule import Molecule
 from syntheseus.reaction_prediction.inference.base import ExternalBackwardReactionModel
 from syntheseus.reaction_prediction.utils.inference import process_raw_smiles_outputs
@@ -60,12 +61,14 @@ class GLNModel(ExternalBackwardReactionModel):
     def get_parameters(self):
         return self.model.gln.parameters()
 
-    def _get_model_predictions(self, input: Molecule, num_results: int) -> BackwardPredictionList:
+    def _get_model_predictions(
+        self, input: Molecule, num_results: int
+    ) -> Sequence[BackwardPrediction]:
         with suppress_outputs():
             result = self.model.run(input.smiles, num_results, num_results)
 
         if result is None:
-            return BackwardPredictionList(input=input, predictions=[])
+            return []
         else:
             # `scores` are actually probabilities (produced by running `softmax`).
             return process_raw_smiles_outputs(
@@ -74,5 +77,7 @@ class GLNModel(ExternalBackwardReactionModel):
                 kwargs_list=[{"probability": probability} for probability in result["scores"]],
             )
 
-    def __call__(self, inputs: List[Molecule], num_results: int) -> List[BackwardPredictionList]:
+    def __call__(
+        self, inputs: List[Molecule], num_results: int
+    ) -> List[Sequence[BackwardPrediction]]:
         return [self._get_model_predictions(input, num_results=num_results) for input in inputs]

--- a/syntheseus/reaction_prediction/inference/local_retro.py
+++ b/syntheseus/reaction_prediction/inference/local_retro.py
@@ -8,10 +8,11 @@ Parts of this file are based on code from the GitHub repository above.
 """
 
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, List
 
-from syntheseus.interface.models import BackwardPredictionList
+from syntheseus.interface.models import BackwardPrediction
 from syntheseus.interface.molecule import Molecule
 from syntheseus.reaction_prediction.inference.base import ExternalBackwardReactionModel
 from syntheseus.reaction_prediction.utils.inference import (
@@ -86,7 +87,7 @@ class LocalRetroModel(ExternalBackwardReactionModel):
 
     def _build_batch_predictions(
         self, batch, num_results: int, inputs: List[Molecule], batch_atom_logits, batch_bond_logits
-    ) -> List[BackwardPredictionList]:
+    ) -> List[Sequence[BackwardPrediction]]:
         from local_retro.scripts.Decode_predictions import get_k_predictions
         from local_retro.scripts.get_edit import combined_edit, get_bg_partition
 
@@ -141,7 +142,9 @@ class LocalRetroModel(ExternalBackwardReactionModel):
 
         return batch_predictions
 
-    def __call__(self, inputs: List[Molecule], num_results: int) -> List[BackwardPredictionList]:
+    def __call__(
+        self, inputs: List[Molecule], num_results: int
+    ) -> List[Sequence[BackwardPrediction]]:
         import torch
         from local_retro.scripts.utils import predict
 

--- a/syntheseus/reaction_prediction/inference/local_retro.py
+++ b/syntheseus/reaction_prediction/inference/local_retro.py
@@ -8,9 +8,8 @@ Parts of this file are based on code from the GitHub repository above.
 """
 
 import sys
-from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, Sequence
 
 from syntheseus.interface.models import BackwardPrediction
 from syntheseus.interface.molecule import Molecule

--- a/syntheseus/reaction_prediction/inference/megan.py
+++ b/syntheseus/reaction_prediction/inference/megan.py
@@ -11,10 +11,9 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from collections.abc import Sequence
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 from rdkit import Chem
 

--- a/syntheseus/reaction_prediction/inference/megan.py
+++ b/syntheseus/reaction_prediction/inference/megan.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from collections.abc import Sequence
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any, Optional
 
 from rdkit import Chem
 
-from syntheseus.interface.models import BackwardPredictionList
+from syntheseus.interface.models import BackwardPrediction
 from syntheseus.interface.molecule import Molecule
 from syntheseus.reaction_prediction.inference.base import ExternalBackwardReactionModel
 from syntheseus.reaction_prediction.utils.inference import (
@@ -140,7 +141,9 @@ class MEGANModel(ExternalBackwardReactionModel):
 
         return input_batch
 
-    def __call__(self, inputs: list[Molecule], num_results: int) -> list[BackwardPredictionList]:
+    def __call__(
+        self, inputs: list[Molecule], num_results: int
+    ) -> list[Sequence[BackwardPrediction]]:
         import torch
         from src.model.beam_search import beam_search
 

--- a/syntheseus/reaction_prediction/inference/mhnreact.py
+++ b/syntheseus/reaction_prediction/inference/mhnreact.py
@@ -8,12 +8,13 @@ The original MHNreact code is released under the BSD-2-Clause license.
 
 import json
 from collections import defaultdict
+from collections.abc import Sequence
 from functools import partial
 from typing import List
 
 from tqdm.contrib import concurrent
 
-from syntheseus.interface.models import BackwardPredictionList
+from syntheseus.interface.models import BackwardPrediction
 from syntheseus.interface.molecule import Molecule
 from syntheseus.reaction_prediction.inference.base import ExternalBackwardReactionModel
 from syntheseus.reaction_prediction.utils.inference import (
@@ -95,7 +96,9 @@ class MHNreactModel(ExternalBackwardReactionModel):
     def get_parameters(self):
         return self.model.parameters()
 
-    def __call__(self, inputs: List[Molecule], num_results: int) -> List[BackwardPredictionList]:
+    def __call__(
+        self, inputs: List[Molecule], num_results: int
+    ) -> List[Sequence[BackwardPrediction]]:
         import pandas as pd
         import torch
 
@@ -153,7 +156,7 @@ class MHNreactModel(ExternalBackwardReactionModel):
         # Now aggregate over same outcome (parts copied from `utils.sort_by_template_and_flatten`,
         # which does not expose the summed probabilities) and build the prediction objects.
 
-        batch_predictions: List[BackwardPredictionList] = []
+        batch_predictions: List[Sequence[BackwardPrediction]] = []
         for idx in range(len(template_scores)):
             idx_prod_reactants = defaultdict(list)
             for k, v in prod_idx_reactants[idx].items():

--- a/syntheseus/reaction_prediction/inference/mhnreact.py
+++ b/syntheseus/reaction_prediction/inference/mhnreact.py
@@ -8,9 +8,8 @@ The original MHNreact code is released under the BSD-2-Clause license.
 
 import json
 from collections import defaultdict
-from collections.abc import Sequence
 from functools import partial
-from typing import List
+from typing import List, Sequence
 
 from tqdm.contrib import concurrent
 

--- a/syntheseus/reaction_prediction/inference/retro_knn.py
+++ b/syntheseus/reaction_prediction/inference/retro_knn.py
@@ -3,12 +3,13 @@
 Paper: https://arxiv.org/abs/2306.04123
 """
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import List, Optional, Union
 
 import numpy as np
 
-from syntheseus.interface.models import BackwardPredictionList
+from syntheseus.interface.models import BackwardPrediction
 from syntheseus.interface.molecule import Molecule
 from syntheseus.reaction_prediction.inference.local_retro import LocalRetroModel
 from syntheseus.reaction_prediction.utils.inference import get_unique_file_in_dir
@@ -76,7 +77,9 @@ class RetroKNNModel(LocalRetroModel):
 
         return atom_outs, bond_outs, atom_feats, bond_feats
 
-    def __call__(self, inputs: List[Molecule], num_results: int) -> List[BackwardPredictionList]:
+    def __call__(
+        self, inputs: List[Molecule], num_results: int
+    ) -> List[Sequence[BackwardPrediction]]:
         import torch
 
         from syntheseus.reaction_prediction.models.retro_knn import knn_prob

--- a/syntheseus/reaction_prediction/inference/retro_knn.py
+++ b/syntheseus/reaction_prediction/inference/retro_knn.py
@@ -3,9 +3,8 @@
 Paper: https://arxiv.org/abs/2306.04123
 """
 
-from collections.abc import Sequence
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Sequence, Union
 
 import numpy as np
 

--- a/syntheseus/reaction_prediction/inference/root_aligned.py
+++ b/syntheseus/reaction_prediction/inference/root_aligned.py
@@ -13,12 +13,13 @@ import multiprocessing
 import random
 import warnings
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import Any, Dict, List, Optional
 
 import yaml
 from rdkit import Chem
 
-from syntheseus.interface.models import PredictionList
+from syntheseus.interface.models import Prediction
 from syntheseus.interface.molecule import Molecule
 from syntheseus.reaction_prediction.inference.base import ExternalBackwardReactionModel
 from syntheseus.reaction_prediction.utils.inference import (
@@ -141,7 +142,9 @@ class RootAlignedModel(ExternalBackwardReactionModel):
 
         return kwargs_list
 
-    def __call__(self, inputs, num_results: int, random_augmentation=False) -> List[PredictionList]:
+    def __call__(
+        self, inputs, num_results: int, random_augmentation=False
+    ) -> List[Sequence[Prediction]]:
         # Step 1: Perform data augmentation.
         augmented_inputs = []
         if random_augmentation:

--- a/syntheseus/reaction_prediction/inference/root_aligned.py
+++ b/syntheseus/reaction_prediction/inference/root_aligned.py
@@ -13,8 +13,7 @@ import multiprocessing
 import random
 import warnings
 from collections import defaultdict
-from collections.abc import Sequence
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 import yaml
 from rdkit import Chem

--- a/syntheseus/reaction_prediction/utils/inference.py
+++ b/syntheseus/reaction_prediction/utils/inference.py
@@ -1,14 +1,15 @@
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
-from syntheseus.interface.models import Prediction, PredictionList
+from syntheseus.interface.models import Prediction
 from syntheseus.reaction_prediction.chem.utils import molecule_bag_from_smiles
 
 
 def process_raw_smiles_outputs(
     input: Any, output_list: List[str], kwargs_list: List[Dict[str, Any]]
-) -> PredictionList:
-    """Convert raw SMILES outputs into a `PredictionList`.
+) -> Sequence[Prediction]:
+    """Convert raw SMILES outputs into a list of `Prediction` objects.
 
     Args:
         inputs: Model input (can be `Molecule` or `Bag[Molecule]` depending on directionality).
@@ -16,7 +17,7 @@ def process_raw_smiles_outputs(
         kwargs_list: Additional metadata to attach to the predictions (e.g. probability).
 
     Returns:
-        A `PredictionList` with the predictions; may be shorter than `outputs` if some of the raw
+        A list of `Predictions`; may be shorter than `outputs` if some of the raw
         SMILES could not be parsed into valid reactant bags.
     """
     predictions: List[Prediction] = []
@@ -28,7 +29,7 @@ def process_raw_smiles_outputs(
         if reactants is not None:
             predictions.append(Prediction(input=input, output=reactants, **kwargs))
 
-    return PredictionList(input=input, predictions=predictions)
+    return predictions
 
 
 def get_unique_file_in_dir(dir: Union[str, Path], pattern: str) -> Path:

--- a/syntheseus/reaction_prediction/utils/inference.py
+++ b/syntheseus/reaction_prediction/utils/inference.py
@@ -16,7 +16,7 @@ def process_raw_smiles_outputs(
         kwargs_list: Additional metadata to attach to the predictions (e.g. probability).
 
     Returns:
-        A list of `Predictions`; may be shorter than `outputs` if some of the raw
+        A list of `Prediction`s; may be shorter than `outputs` if some of the raw
         SMILES could not be parsed into valid reactant bags.
     """
     predictions: List[Prediction] = []

--- a/syntheseus/reaction_prediction/utils/inference.py
+++ b/syntheseus/reaction_prediction/utils/inference.py
@@ -1,6 +1,5 @@
-from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Sequence, Union
 
 from syntheseus.interface.models import Prediction
 from syntheseus.reaction_prediction.chem.utils import molecule_bag_from_smiles

--- a/syntheseus/reaction_prediction/utils/misc.py
+++ b/syntheseus/reaction_prediction/utils/misc.py
@@ -50,7 +50,7 @@ def dictify(data: Any) -> Any:
     elif isinstance(data, Molecule):
         return {"smiles": data.smiles}
     elif isinstance(data, (List, tuple, Bag)):
-        # Captures possible lists of `Prediction`s and lists of `PredictionList`s
+        # Captures lists of `Prediction`s
         return [dictify(x) for x in data]
     elif isinstance(data, dict):
         return {k: dictify(v) for k, v in data.items()}

--- a/syntheseus/reaction_prediction/utils/parallel.py
+++ b/syntheseus/reaction_prediction/utils/parallel.py
@@ -1,6 +1,5 @@
 import math
-from collections.abc import Sequence
-from typing import Callable, List
+from typing import Callable, List, Sequence
 
 import torch
 from more_itertools import chunked

--- a/syntheseus/reaction_prediction/utils/parallel.py
+++ b/syntheseus/reaction_prediction/utils/parallel.py
@@ -1,13 +1,14 @@
 import math
+from collections.abc import Sequence
 from typing import Callable, List
 
 import torch
 from more_itertools import chunked
 
-from syntheseus.interface.models import InputType, OutputType, PredictionList, ReactionModel
+from syntheseus.interface.models import InputType, OutputType, Prediction, ReactionModel
 
 
-class ParallelReactionModel(ReactionModel):
+class ParallelReactionModel(ReactionModel[InputType, OutputType]):
     """Wraps an arbitrary `ReactionModel` to enable multi-GPU inference.
 
     Unlike most off-the-shelf multi-GPU approaches (e.g. strategies in `pytorch_lightning`,
@@ -23,7 +24,7 @@ class ParallelReactionModel(ReactionModel):
 
     def __call__(
         self, inputs: List[InputType], num_results: int
-    ) -> List[PredictionList[InputType, OutputType]]:
+    ) -> List[Sequence[Prediction[InputType, OutputType]]]:
         # Chunk up the inputs into (roughly) equal-sized chunks.
         chunk_size = math.ceil(len(inputs) / len(self._devices))
         input_chunks = list((input,) for input in chunked(inputs, chunk_size))

--- a/syntheseus/reaction_prediction/utils/syntheseus_wrapper.py
+++ b/syntheseus/reaction_prediction/utils/syntheseus_wrapper.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import syntheseus.search.reaction_models
 from syntheseus.interface.models import BackwardReactionModel
 from syntheseus.interface.molecule import Molecule
@@ -19,14 +21,15 @@ class SyntheseusBackwardReactionModel(syntheseus.search.reaction_models.Backward
         self._model = model
         self._num_results = num_results
 
-    def _get_backward_reactions(self, mols: list[Molecule]) -> list[list[BackwardReaction]]:
+    def _get_backward_reactions(self, mols: list[Molecule]) -> list[Sequence[BackwardReaction]]:
         # Call the underlying model
         model_outputs = self._model(mols, self._num_results)
 
         # Convert the outputs to backward reactions
-        reaction_outputs: list[list[BackwardReaction]] = []
+        reaction_outputs: list[Sequence[BackwardReaction]] = []
         for pred_list in model_outputs:
-            reaction_outputs.append([])  # Initialize the list
+            replacement_list: list[BackwardReaction] = []
+            reaction_outputs.append(replacement_list)  # Initialize the list
             for pred in pred_list:
                 # Read metadata
                 metadata = ReactionMetaData()
@@ -49,5 +52,5 @@ class SyntheseusBackwardReactionModel(syntheseus.search.reaction_models.Backward
                 rxn = BackwardReaction(
                     product=pred.input, reactants=frozenset(pred.output), metadata=metadata
                 )
-                reaction_outputs[-1].append(rxn)
+                replacement_list.append(rxn)
         return reaction_outputs

--- a/syntheseus/reaction_prediction/utils/syntheseus_wrapper.py
+++ b/syntheseus/reaction_prediction/utils/syntheseus_wrapper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import Sequence
 
 import syntheseus.search.reaction_models
 from syntheseus.interface.models import BackwardReactionModel

--- a/syntheseus/reaction_prediction/utils/syntheseus_wrapper.py
+++ b/syntheseus/reaction_prediction/utils/syntheseus_wrapper.py
@@ -27,7 +27,7 @@ class SyntheseusBackwardReactionModel(syntheseus.search.reaction_models.Backward
         reaction_outputs: list[list[BackwardReaction]] = []
         for pred_list in model_outputs:
             reaction_outputs.append([])  # Initialize the list
-            for pred in pred_list.predictions:
+            for pred in pred_list:
                 # Read metadata
                 metadata = ReactionMetaData()
 

--- a/syntheseus/search/algorithms/base.py
+++ b/syntheseus/search/algorithms/base.py
@@ -225,7 +225,7 @@ class SearchAlgorithm(MinimalSearchAlgorithm[GraphType, AlgReturnType]):
 
     @abc.abstractmethod
     def _filter_reactions(
-        self, reactions: list[BackwardReaction], node: BaseGraphNode, graph: GraphType
+        self, reactions: Sequence[BackwardReaction], node: BaseGraphNode, graph: GraphType
     ) -> list[BackwardReaction]:
         """Remove unwanted reactions from the list."""
         raise NotImplementedError
@@ -318,7 +318,7 @@ class AndOrSearchAlgorithm(SearchAlgorithm[AndOrGraph, AlgReturnType], Generic[A
         return mols
 
     def _filter_reactions(
-        self, reactions: list[BackwardReaction], node: BaseGraphNode, graph: AndOrGraph
+        self, reactions: Sequence[BackwardReaction], node: BaseGraphNode, graph: AndOrGraph
     ) -> list[BackwardReaction]:
         # Filter out any reactions that contain the root molecule
         reactions = [rxn for rxn in reactions if graph.root_node.mol not in rxn.reactants]
@@ -372,7 +372,7 @@ class MolSetSearchAlgorithm(SearchAlgorithm[MolSetGraph, AlgReturnType], Generic
         return molsets
 
     def _filter_reactions(
-        self, reactions: list[BackwardReaction], node: BaseGraphNode, graph: MolSetGraph
+        self, reactions: Sequence[BackwardReaction], node: BaseGraphNode, graph: MolSetGraph
     ) -> list[BackwardReaction]:
         # Filter out any reactions that contain the root molecule
         assert len(graph.root_node.mols) == 1

--- a/syntheseus/search/algorithms/base.py
+++ b/syntheseus/search/algorithms/base.py
@@ -4,9 +4,9 @@ import abc
 import math
 import random
 import warnings
-from collections.abc import Collection, Sequence
+from collections.abc import Collection
 from datetime import datetime
-from typing import Generic, Optional, TypeVar
+from typing import Generic, Optional, Sequence, TypeVar
 
 from syntheseus.search import INT_INF
 from syntheseus.search.chem import BackwardReaction, Molecule

--- a/syntheseus/search/algorithms/best_first/base.py
+++ b/syntheseus/search/algorithms/best_first/base.py
@@ -4,8 +4,7 @@ import abc
 import heapq
 import logging
 import math
-from collections.abc import Sequence
-from typing import Generic
+from typing import Generic, Sequence
 
 from syntheseus.search.algorithms.base import GraphType, SearchAlgorithm
 from syntheseus.search.graph.node import BaseGraphNode

--- a/syntheseus/search/algorithms/best_first/retro_star.py
+++ b/syntheseus/search/algorithms/best_first/retro_star.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 
 # NOTE: Collection imported here instead of from collections.abc
 # to make casting work for python <3.9
 from typing import (
     Collection,
     Optional,
+    Sequence,
     cast,
 )
 

--- a/syntheseus/search/algorithms/mcts/base.py
+++ b/syntheseus/search/algorithms/mcts/base.py
@@ -5,9 +5,8 @@ import logging
 import math
 import random
 import warnings
-from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Callable, Generic, Optional, TypeVar, cast
+from typing import Callable, Generic, Optional, Sequence, TypeVar, cast
 
 import numpy as np
 

--- a/syntheseus/search/algorithms/pdvn.py
+++ b/syntheseus/search/algorithms/pdvn.py
@@ -12,9 +12,8 @@ from __future__ import annotations
 import enum
 import math
 from collections import defaultdict
-from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Sequence
 
 from syntheseus.search.algorithms.base import AndOrSearchAlgorithm
 from syntheseus.search.algorithms.mcts.base import BaseMCTS, pucb_bound

--- a/syntheseus/search/graph/and_or.py
+++ b/syntheseus/search/graph/and_or.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import datetime
 from collections import Counter
-from collections.abc import Collection, Sequence
+from collections.abc import Collection
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional, Sequence, Union
 
 import networkx as nx
 

--- a/syntheseus/search/graph/base_graph.py
+++ b/syntheseus/search/graph/base_graph.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Container, Iterable, Sequence, Sized
-from typing import Generic, TypeVar
+from collections.abc import Container, Iterable, Sized
+from typing import Generic, Sequence, TypeVar
 
 import networkx as nx
 

--- a/syntheseus/search/graph/message_passing/run.py
+++ b/syntheseus/search/graph/message_passing/run.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 from collections import deque
-from collections.abc import Collection, Iterable, Sequence
-from typing import Callable, TypeVar
+from collections.abc import Collection, Iterable
+from typing import Callable, Sequence, TypeVar
 
 from syntheseus.search import INT_INF
 from syntheseus.search.graph.base_graph import RetrosynthesisSearchGraph

--- a/syntheseus/search/graph/molset.py
+++ b/syntheseus/search/graph/molset.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import datetime
 import warnings
 from collections import Counter
-from collections.abc import Collection, Sequence
+from collections.abc import Collection
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
 
 import networkx as nx
 

--- a/syntheseus/search/graph/route.py
+++ b/syntheseus/search/graph/route.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Sequence
-from typing import Union
+from typing import Sequence, Union
 
 from syntheseus.search.chem import BackwardReaction, Molecule
 from syntheseus.search.graph.base_graph import BaseReactionGraph

--- a/syntheseus/search/node_evaluation/base.py
+++ b/syntheseus/search/node_evaluation/base.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Sequence
-from typing import Generic, Optional, TypeVar
+from typing import Generic, Optional, Sequence, TypeVar
 
 import numpy as np
 

--- a/syntheseus/search/node_evaluation/common.py
+++ b/syntheseus/search/node_evaluation/common.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Union
+from typing import Sequence, Union
 
 from syntheseus.search.chem import BackwardReaction
 from syntheseus.search.graph.and_or import AndNode

--- a/syntheseus/search/reaction_models/base.py
+++ b/syntheseus/search/reaction_models/base.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import abc
 import warnings
-from collections.abc import Sequence
-from typing import Optional
+from typing import Optional, Sequence
 
 from syntheseus.search.chem import BackwardReaction, Molecule
 

--- a/syntheseus/search/reaction_models/base.py
+++ b/syntheseus/search/reaction_models/base.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import abc
 import warnings
+from collections.abc import Sequence
 from typing import Optional
 
 from syntheseus.search.chem import BackwardReaction, Molecule
 
 
-def remove_duplicate_reactions(reaction_list: list[BackwardReaction]) -> list[BackwardReaction]:
+def remove_duplicate_reactions(reaction_list: Sequence[BackwardReaction]) -> list[BackwardReaction]:
     """
     Remove reactions with the same product/reactants, since these are effectively
     redundant. E.g., if the input is something like
@@ -46,14 +47,14 @@ class BackwardReactionModel(abc.ABC):
         remove_duplicates: bool = True,
         use_cache: bool = True,
         count_cache_in_num_calls: bool = False,
-        initial_cache: Optional[dict[Molecule, list[BackwardReaction]]] = None,
+        initial_cache: Optional[dict[Molecule, Sequence[BackwardReaction]]] = None,
     ) -> None:
         self.count_cache_in_num_calls = count_cache_in_num_calls
 
         # These attributes should not be modified manually,
         # since doing so will likely make counts/etc inaccurate
         self._use_cache = use_cache
-        self._cache: dict[Molecule, list[BackwardReaction]] = dict()
+        self._cache: dict[Molecule, Sequence[BackwardReaction]] = dict()
         self._remove_duplicates = remove_duplicates
         self.reset()
 
@@ -100,7 +101,9 @@ class BackwardReactionModel(abc.ABC):
         else:
             return self._num_cache_misses
 
-    def filter_reactions(self, reaction_list: list[BackwardReaction]) -> list[BackwardReaction]:
+    def filter_reactions(
+        self, reaction_list: Sequence[BackwardReaction]
+    ) -> Sequence[BackwardReaction]:
         """
         Filters a list of reactions. In the base version this just removes duplicates,
         but subclasses could add additional behaviour or override this.
@@ -110,7 +113,7 @@ class BackwardReactionModel(abc.ABC):
         else:
             return list(reaction_list)
 
-    def __call__(self, mols: list[Molecule]) -> list[list[BackwardReaction]]:
+    def __call__(self, mols: list[Molecule]) -> list[Sequence[BackwardReaction]]:
         """Return all backward reactions."""
 
         # Step 1: call underlying model for all mols not in the cache,
@@ -136,7 +139,7 @@ class BackwardReactionModel(abc.ABC):
         return output
 
     @abc.abstractmethod
-    def _get_backward_reactions(self, mols: list[Molecule]) -> list[list[BackwardReaction]]:
+    def _get_backward_reactions(self, mols: list[Molecule]) -> list[Sequence[BackwardReaction]]:
         """
         Method to override which returns the underlying reactions.
         It is encouraged (but not mandatory) that the order of reactions is stable

--- a/syntheseus/search/reaction_models/toy.py
+++ b/syntheseus/search/reaction_models/toy.py
@@ -13,7 +13,7 @@ class ListOfReactionsModel(BackwardReactionModel):
         super().__init__(**kwargs)
         self.reaction_list = list(reaction_list)
 
-    def _get_backward_reactions(self, mols: list[Molecule]) -> list[list[BackwardReaction]]:
+    def _get_backward_reactions(self, mols: list[Molecule]) -> list[Sequence[BackwardReaction]]:
         return [[r for r in self.reaction_list if r.product == mol] for mol in mols]
 
 
@@ -78,5 +78,5 @@ class LinearMolecules(BackwardReactionModel):
 
         return output
 
-    def _get_backward_reactions(self, mols: list[Molecule]) -> list[list[BackwardReaction]]:
+    def _get_backward_reactions(self, mols: list[Molecule]) -> list[Sequence[BackwardReaction]]:
         return [self._get_single_backward_reactions(mol) for mol in mols]

--- a/syntheseus/search/reaction_models/toy.py
+++ b/syntheseus/search/reaction_models/toy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import Sequence
 
 from syntheseus.search.chem import BackwardReaction, Molecule
 from syntheseus.search.reaction_models.base import BackwardReactionModel

--- a/syntheseus/tests/interface/test_models.py
+++ b/syntheseus/tests/interface/test_models.py
@@ -2,7 +2,7 @@ import math
 
 import numpy as np
 
-from syntheseus.interface.models import Prediction, PredictionList
+from syntheseus.interface.models import Prediction
 from syntheseus.interface.molecule import Molecule
 
 # TODO(kmaziarz): Currently this test mostly checks that importing from `models.py` works, and that
@@ -14,10 +14,4 @@ def test_prediction():
     assert np.isclose(prediction.get_prob(), 0.5)
     assert np.isclose(prediction.get_log_prob(), math.log(0.5))
 
-    other_prediction = Prediction(input=Molecule("N"), output=Molecule("NC=O"), probability=0.5)
-    prediction_list = PredictionList(
-        input=Molecule("C"), predictions=[prediction, other_prediction]
-    )
-
-    assert prediction_list.predictions == [prediction, other_prediction]
-    assert prediction_list.truncated(num_results=1).predictions == [prediction]
+    Prediction(input=Molecule("N"), output=Molecule("NC=O"), probability=0.5)

--- a/syntheseus/tests/reaction_prediction/cli/test_eval.py
+++ b/syntheseus/tests/reaction_prediction/cli/test_eval.py
@@ -1,7 +1,6 @@
 import tempfile
-from collections.abc import Sequence
 from itertools import cycle, islice
-from typing import Iterable, List
+from typing import Iterable, List, Sequence
 
 import pytest
 

--- a/syntheseus/tests/reaction_prediction/cli/test_eval.py
+++ b/syntheseus/tests/reaction_prediction/cli/test_eval.py
@@ -1,4 +1,5 @@
 import tempfile
+from collections.abc import Sequence
 from itertools import cycle, islice
 from typing import Iterable, List
 
@@ -13,7 +14,6 @@ from syntheseus.cli.eval_single_step import (
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.models import (
     BackwardPrediction,
-    BackwardPredictionList,
     BackwardReactionModel,
 )
 from syntheseus.interface.molecule import Molecule
@@ -32,7 +32,9 @@ class DummyModel(BackwardReactionModel):
         Bag([Molecule("NC=O")]),
     ]
 
-    def __call__(self, inputs: List[Molecule], num_results: int) -> List[BackwardPredictionList]:
+    def __call__(
+        self, inputs: List[Molecule], num_results: int
+    ) -> List[Sequence[BackwardPrediction]]:
         outputs: Iterable[Bag[Molecule]] = []
 
         if self._repeat:
@@ -43,10 +45,7 @@ class DummyModel(BackwardReactionModel):
 
         # Return the same outputs for each input molecule.
         return [
-            BackwardPredictionList(
-                input=input,
-                predictions=[BackwardPrediction(input=input, output=output) for output in outputs],
-            )
+            [BackwardPrediction(input=input, output=output) for output in outputs]
             for input in inputs
         ]
 
@@ -62,7 +61,7 @@ def test_get_results(repeat: bool, measure_time: bool) -> None:
         assert (model_results.model_timing_results is not None) == measure_time
 
         prediction_list = model_results.results[0]
-        return [prediction.output for prediction in prediction_list.predictions]
+        return [prediction.output for prediction in prediction_list]
 
     for num_results in [1, 2, 3, 4, 20]:
         assert get_model_results(num_results=num_results) == [
@@ -96,12 +95,7 @@ def test_print_and_save():
         mean_num_predictions=25.0,
         median_num_predictions=10.0,
         model_time_total=ModelTimingResults(time_model_call=1.0, time_post_processing=0.1),
-        predictions=[
-            BackwardPredictionList(
-                input=input_mol,
-                predictions=[BackwardPrediction(input=input_mol, output=output_mol_bag)],
-            )
-        ],
+        predictions=[BackwardPrediction(input=input_mol, output=output_mol_bag)],
     )
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/syntheseus/tests/reaction_prediction/cli/test_eval.py
+++ b/syntheseus/tests/reaction_prediction/cli/test_eval.py
@@ -94,7 +94,7 @@ def test_print_and_save():
         mean_num_predictions=25.0,
         median_num_predictions=10.0,
         model_time_total=ModelTimingResults(time_model_call=1.0, time_post_processing=0.1),
-        predictions=[BackwardPrediction(input=input_mol, output=output_mol_bag)],
+        predictions=[[BackwardPrediction(input=input_mol, output=output_mol_bag)]],
     )
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/syntheseus/tests/reaction_prediction/inference/test_models.py
+++ b/syntheseus/tests/reaction_prediction/inference/test_models.py
@@ -51,7 +51,7 @@ def model(request) -> ExternalBackwardReactionModel:
 
 def test_call(model: ExternalBackwardReactionModel) -> None:
     [result] = model([Molecule("Cc1ccc(-c2ccc(C)cc2)cc1")], num_results=20)
-    model_predictions = [prediction.output for prediction in result.predictions]
+    model_predictions = [prediction.output for prediction in result]
 
     # Prepare some coupling reactions that are reasonable predictions for the product above.
     expected_predictions = [

--- a/syntheseus/tests/reaction_prediction/utils/test_syntheseus_wrapper.py
+++ b/syntheseus/tests/reaction_prediction/utils/test_syntheseus_wrapper.py
@@ -1,10 +1,10 @@
+from collections.abc import Sequence
 from typing import List
 
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.models import (
     BackwardReactionModel,
     Prediction,
-    PredictionList,
 )
 from syntheseus.interface.molecule import Molecule
 from syntheseus.reaction_prediction.utils.syntheseus_wrapper import (
@@ -18,11 +18,8 @@ class MockBackwardReactionModel(BackwardReactionModel):
 
     def __call__(
         self, inputs: List[Molecule], num_results: int
-    ) -> List[PredictionList[Molecule, Bag[Molecule]]]:
-        return [
-            PredictionList(input=mol, predictions=[Prediction(input=mol, output=Bag([mol]))])
-            for mol in inputs
-        ]
+    ) -> List[Sequence[Prediction[Molecule, Bag[Molecule]]]]:
+        return [[Prediction(input=mol, output=Bag([mol]))] for mol in inputs]
 
     def get_parameters(self):
         return []

--- a/syntheseus/tests/reaction_prediction/utils/test_syntheseus_wrapper.py
+++ b/syntheseus/tests/reaction_prediction/utils/test_syntheseus_wrapper.py
@@ -1,5 +1,4 @@
-from collections.abc import Sequence
-from typing import List
+from typing import List, Sequence
 
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.models import (

--- a/tutorials/search/paroutes.py
+++ b/tutorials/search/paroutes.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Sequence
 from pathlib import Path
+from typing import Sequence
 
 import numpy as np
 import pandas as pd

--- a/tutorials/search/paroutes.py
+++ b/tutorials/search/paroutes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
@@ -87,7 +88,7 @@ class PaRoutesModel(BackwardReactionModel):
             },
         )
 
-    def _get_backward_reactions(self, mols: list[Molecule]) -> list[list[BackwardReaction]]:
+    def _get_backward_reactions(self, mols: list[Molecule]) -> list[Sequence[BackwardReaction]]:
         # Make fingerprint array
         fingperprints = np.array([get_fingerprint(mol.smiles) for mol in mols])
 


### PR DESCRIPTION
This PR replaces `PredictionList` objects (and their subclasses) with `Sequence[Prediction]`. It is meant as the first step to merge the two kinds of reaction model interfaces. The `PredictionList` class was then deleted.

I chose `Sequence[Prediction]` instead of `list[Prediction]` to allow `PredictionList`-like functionality in the future if we ever desire it. This would be implemented by subclassing `Sequence`.

I also changed the search `BackwardReactionModel` class to return `list[Sequence]` instead of `list[list]` to prepare for the class merger in a subsequent PR.