### PR TITLE
Improve retro* implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
+- Improve efficiency and logging of retro* algorithm ([#62](https://github.com/microsoft/syntheseus/pull/62)) ([@austint])
 
 ### Added
 

--- a/syntheseus/search/algorithms/best_first/base.py
+++ b/syntheseus/search/algorithms/best_first/base.py
@@ -68,13 +68,20 @@ class PriorityQueue:
                 # (if `None` is added to the queue there may be multiple `None` items)
                 del self._entry_finder[entry.item]
                 return entry
-        raise KeyError("pop from an empty priority queue")
+        raise IndexError("pop from an empty priority queue")
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Length is number of unique items in the queue."""
         return len(self._entry_finder)
 
-    def raw_len(self):
+    def __contains__(self, item) -> bool:
+        return item in self._entry_finder
+
+    def get_priority(self, item) -> Any:
+        """Returns the priority of an item in the queue, raising KeyError if not found."""
+        return self._entry_finder[item].priority
+
+    def raw_len(self) -> int:
         return len(self._queue)
 
 
@@ -165,11 +172,8 @@ class GeneralBestFirstSearch(SearchAlgorithm[GraphType, int], Generic[GraphType]
             for updated_node in dict.fromkeys(new_nodes + list(nodes_updated)):
                 if self.node_eligible_for_queue(updated_node, graph):
                     updated_node_priority = self.priority_function(updated_node, graph)
-                    already_in_queue_at_correct_priority = (
-                        updated_node in queue._entry_finder
-                        and math.isclose(
-                            queue._entry_finder[updated_node].priority, updated_node_priority
-                        )
+                    already_in_queue_at_correct_priority = updated_node in queue and math.isclose(
+                        queue.get_priority(updated_node), updated_node_priority
                     )
 
                     if already_in_queue_at_correct_priority:

--- a/syntheseus/search/algorithms/best_first/base.py
+++ b/syntheseus/search/algorithms/best_first/base.py
@@ -136,9 +136,8 @@ class GeneralBestFirstSearch(SearchAlgorithm[GraphType, int], Generic[GraphType]
                 break
 
             # Take nodes from the priority queue until a node eligible for expansion is found
-            found_node = False
             num_popped = 0
-            while len(queue) > 0 and not found_node:
+            while len(queue) > 0:
                 pq_item = queue.pop_item()
                 num_popped += 1
 
@@ -149,9 +148,9 @@ class GeneralBestFirstSearch(SearchAlgorithm[GraphType, int], Generic[GraphType]
                 ), "priority is not up-to-date. This should not happen."
 
                 if self.node_eligible_for_queue(pq_item.item, graph):
-                    found_node = True
                     node = pq_item.item
-            if not found_node:
+                    break
+            else:
                 logger.log(log_level, "No eligible node found. Stopping search.")
                 break
 

--- a/syntheseus/search/algorithms/best_first/base.py
+++ b/syntheseus/search/algorithms/best_first/base.py
@@ -172,22 +172,33 @@ class GeneralBestFirstSearch(SearchAlgorithm[GraphType, int], Generic[GraphType]
                             queue._entry_finder[updated_node].priority, updated_node_priority
                         )
                     )
-                    if (
-                        not already_in_queue_at_correct_priority
-                        and updated_node_priority < math.inf
-                    ):
+
+                    if already_in_queue_at_correct_priority:
+                        # In this case re-inserting the node is redundant so we do nothing
+                        pass
+                    elif updated_node_priority < math.inf:
+                        # Main case: insert (or re-insert) node into queue
                         queue.push_item(updated_node, updated_node_priority)
+                    else:
+                        # Edge case: reached if new priority is inf.
+                        # In this case, remove the node from the queue if it was there.
+                        queue.remove_item(updated_node)
 
             # Log
             if logger_active:
+                logging_str = (
+                    f"Step: {step}, "
+                    f"Nodes affected during visit: {len(new_nodes)}, "
+                    f"Nodes updated: {len(nodes_updated)}, "
+                    f"Graph size: {len(graph)}, "
+                    f"Queue size: {len(queue)} (raw length: {queue.raw_len()}), "
+                    f"Num popped: {num_popped}, "
+                    f"Reaction model calls: {self.reaction_model.num_calls()}, "
+                    f"Node visited: {node}"
+                )
                 logger.log(
                     log_level,
-                    f"Step {step}:\tvisited node: {node}, "
-                    f"Nodes effected during visit: {len(new_nodes)}, "
-                    f"Nodes updated: {len(nodes_updated)}, "
-                    f"Graph size: {len(graph)}, ",
-                    f"Queue size: {len(queue)} (raw length: {queue.raw_len()}), ",
-                    f"Num popped: {num_popped}",
+                    logging_str,
                 )
 
         return step

--- a/syntheseus/search/algorithms/best_first/base.py
+++ b/syntheseus/search/algorithms/best_first/base.py
@@ -31,22 +31,21 @@ class PriorityQueue:
     https://docs.python.org/3/library/heapq.html#priority-queue-implementation-notes
 
     In particular, this means items are never really removed from the queue:
-    they are just marked as invalid. This is why the queue length is not
-    necessarily the same as the number of unique items in the queue.
-    It also assumes that items are unique and hashable.
+    they are just marked as invalid and set to `None`. This is why the queue
+    length is not necessarily the same as the number of unique items in the
+    queue. It also assumes that items are unique and hashable.
     """
 
     def __init__(self):
         self._queue = []
         self._entry_finder = {}
         self._counter = itertools.count()  # to break ties in priority
-        self._REMOVED = None
 
     def remove_item(self, item):
         """Removes and item if it is present."""
         if item in self._entry_finder:
             entry = self._entry_finder.pop(item)
-            entry.item = self._REMOVED
+            entry.item = None
 
     def push_item(self, item, priority):
         """
@@ -64,7 +63,10 @@ class PriorityQueue:
         """Removes an item with the lowest priority and returns it."""
         while self._queue:
             entry = heapq.heappop(self._queue)
-            if entry.item is not self._REMOVED:
+            if self._entry_finder.get(entry.item) == entry:
+                # ^^ ensures 1) item in entry finder and
+                # 2) item in entry finder has the same priority as the popped item
+                # (if `None` is added to the queue there may be multiple `None` items)
                 del self._entry_finder[entry.item]
                 return entry
         raise KeyError("pop from an empty priority queue")

--- a/syntheseus/search/algorithms/best_first/base.py
+++ b/syntheseus/search/algorithms/best_first/base.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(order=True)
 class PriorityQueueItem:
-    priority: float
+    priority: Any  # usually float, but just needs to be comparable
     tie_breaker: int
     item: Any = field(compare=False)
 

--- a/syntheseus/search/algorithms/best_first/base.py
+++ b/syntheseus/search/algorithms/best_first/base.py
@@ -23,7 +23,6 @@ class PriorityQueueItem:
 
 class PriorityQueue:
     """
-
     Simple priority queue implementation which supports removing elements
     and changing their priority.
 
@@ -42,7 +41,7 @@ class PriorityQueue:
         self._counter = itertools.count()  # to break ties in priority
 
     def remove_item(self, item):
-        """Removes and item if it is present."""
+        """Removes an item if it is present."""
         if item in self._entry_finder:
             entry = self._entry_finder.pop(item)
             entry.item = None
@@ -143,10 +142,10 @@ class GeneralBestFirstSearch(SearchAlgorithm[GraphType, int], Generic[GraphType]
                 num_popped += 1
 
                 # Do a few checks
-                assert pq_item.priority < math.inf, "inf priority should not be in the queue"
+                assert pq_item.priority < math.inf, "Inf priority should not be in the queue"
                 assert math.isclose(
                     pq_item.priority, self.priority_function(pq_item.item, graph)
-                ), "priority is not up-to-date. This should not happen."
+                ), "Priority in the queue should always be up-to-date"
 
                 if self.node_eligible_for_queue(pq_item.item, graph):
                     node = pq_item.item

--- a/syntheseus/search/algorithms/best_first/retro_star.py
+++ b/syntheseus/search/algorithms/best_first/retro_star.py
@@ -92,7 +92,7 @@ class RetroStarSearch(
                 for node in output_nodes
                 if isinstance(node, OrNode)
                 and "reaction_number_estimate" not in node.data
-                and not node.is_expanded
+                and self.can_expand_node(node, graph)
             ],
             graph=graph,
         )
@@ -226,9 +226,9 @@ def reaction_number_update(node: ANDOR_NODE, graph: AndOrGraph) -> bool:
             possible_costs.extend(
                 [c.data["retro_star_reaction_number"] for c in graph.successors(node)]
             )
-        else:
+        elif "reaction_number_estimate" in node.data:
             # Otherwise the cost of the reaction number estimate is an option.
-            # This estimate must be present!
+            # By design, it will only be present if the node can be expanded
             possible_costs.append(node.data["reaction_number_estimate"])
         new_rn = min(possible_costs)
     else:

--- a/syntheseus/search/algorithms/best_first/retro_star.py
+++ b/syntheseus/search/algorithms/best_first/retro_star.py
@@ -132,7 +132,7 @@ class RetroStarSearch(
 
         # Perform bottom-up update of `retro_star_min_cost`,
         # sorting by decreasing depth and not updating children for efficiency
-        # (min costs depends only on children)
+        # (min cost depends only on children)
         nodes_to_update.update(
             cast(  # mypy doesn't know that `run_message_passing` returns a `Collection[ANDOR_NODE]`
                 Collection[ANDOR_NODE],

--- a/syntheseus/search/graph/node.py
+++ b/syntheseus/search/graph/node.py
@@ -31,7 +31,7 @@ class _NodeData_Algorithms(TypedDict, total=False):
     # Retro*
     # ==================================================
     retro_star_min_cost: float  # minimum cost found so far
-    reaction_number: float
+    retro_star_reaction_number: float
     reaction_number_estimate: float
     retro_star_value: float
     retro_star_rxn_cost: float

--- a/syntheseus/search/graph/node.py
+++ b/syntheseus/search/graph/node.py
@@ -30,6 +30,7 @@ class _NodeData_Algorithms(TypedDict, total=False):
     # ==================================================
     # Retro*
     # ==================================================
+    retro_star_min_cost: float  # minimum cost found so far
     reaction_number: float
     reaction_number_estimate: float
     retro_star_value: float

--- a/syntheseus/tests/search/algorithms/test_best_first.py
+++ b/syntheseus/tests/search/algorithms/test_best_first.py
@@ -123,6 +123,7 @@ class TestRetroStar(BaseAlgorithmTest):
         assert get_first_solution_time(output_graph) == math.inf
         assert math.isclose(output_graph.root_node.data["retro_star_value"], 0.6)
         assert math.isclose(output_graph.root_node.data["reaction_number"], 0.6)
+        assert math.isclose(output_graph.root_node.data["retro_star_min_cost"], math.inf)
         assert_retro_star_values_in_graph(output_graph, [1.9, 0.6, 1.1])
 
     def test_by_hand_step2(
@@ -161,6 +162,7 @@ class TestRetroStar(BaseAlgorithmTest):
         assert get_first_solution_time(output_graph) == math.inf
         assert math.isclose(output_graph.root_node.data["retro_star_value"], 0.6)
         assert math.isclose(output_graph.root_node.data["reaction_number"], 0.6)
+        assert math.isclose(output_graph.root_node.data["retro_star_min_cost"], math.inf)
         assert_retro_star_values_in_graph(output_graph, [5.6, 1.1, 0.6, 1.9])
 
     def test_by_hand_step3(
@@ -206,6 +208,7 @@ class TestRetroStar(BaseAlgorithmTest):
         assert get_first_solution_time(output_graph) == 3
         assert math.isclose(output_graph.root_node.data["retro_star_value"], 1.1)
         assert math.isclose(output_graph.root_node.data["reaction_number"], 1.1)
+        assert math.isclose(output_graph.root_node.data["retro_star_min_cost"], 2.6)
         assert_retro_star_values_in_graph(output_graph, [5.6, 1.1, 2.6, 1.9, 5.7])
 
     def test_by_hand_step4(
@@ -256,6 +259,7 @@ class TestRetroStar(BaseAlgorithmTest):
         assert get_first_solution_time(output_graph) == 3
         assert math.isclose(output_graph.root_node.data["retro_star_value"], 1.9)
         assert math.isclose(output_graph.root_node.data["reaction_number"], 1.9)
+        assert math.isclose(output_graph.root_node.data["retro_star_min_cost"], 2.6)
         assert_retro_star_values_in_graph(output_graph, [1.9, 5.6, 2.6, 2.1, 5.7])
 
     def test_by_hand_step5(
@@ -305,4 +309,5 @@ class TestRetroStar(BaseAlgorithmTest):
         assert get_first_solution_time(output_graph) == 3
         assert math.isclose(output_graph.root_node.data["retro_star_value"], 1.6)
         assert math.isclose(output_graph.root_node.data["reaction_number"], 1.6)
+        assert math.isclose(output_graph.root_node.data["retro_star_min_cost"], 1.6)
         assert_retro_star_values_in_graph(output_graph, [1.6, 2.6, 2.1])

--- a/syntheseus/tests/search/algorithms/test_best_first.py
+++ b/syntheseus/tests/search/algorithms/test_best_first.py
@@ -122,7 +122,7 @@ class TestRetroStar(BaseAlgorithmTest):
         assert not output_graph.root_node.has_solution
         assert get_first_solution_time(output_graph) == math.inf
         assert math.isclose(output_graph.root_node.data["retro_star_value"], 0.6)
-        assert math.isclose(output_graph.root_node.data["reaction_number"], 0.6)
+        assert math.isclose(output_graph.root_node.data["retro_star_reaction_number"], 0.6)
         assert math.isclose(output_graph.root_node.data["retro_star_min_cost"], math.inf)
         assert_retro_star_values_in_graph(output_graph, [1.9, 0.6, 1.1])
 
@@ -161,7 +161,7 @@ class TestRetroStar(BaseAlgorithmTest):
         assert not output_graph.root_node.has_solution
         assert get_first_solution_time(output_graph) == math.inf
         assert math.isclose(output_graph.root_node.data["retro_star_value"], 0.6)
-        assert math.isclose(output_graph.root_node.data["reaction_number"], 0.6)
+        assert math.isclose(output_graph.root_node.data["retro_star_reaction_number"], 0.6)
         assert math.isclose(output_graph.root_node.data["retro_star_min_cost"], math.inf)
         assert_retro_star_values_in_graph(output_graph, [5.6, 1.1, 0.6, 1.9])
 
@@ -207,7 +207,7 @@ class TestRetroStar(BaseAlgorithmTest):
         assert output_graph.root_node.has_solution
         assert get_first_solution_time(output_graph) == 3
         assert math.isclose(output_graph.root_node.data["retro_star_value"], 1.1)
-        assert math.isclose(output_graph.root_node.data["reaction_number"], 1.1)
+        assert math.isclose(output_graph.root_node.data["retro_star_reaction_number"], 1.1)
         assert math.isclose(output_graph.root_node.data["retro_star_min_cost"], 2.6)
         assert_retro_star_values_in_graph(output_graph, [5.6, 1.1, 2.6, 1.9, 5.7])
 
@@ -258,7 +258,7 @@ class TestRetroStar(BaseAlgorithmTest):
         assert output_graph.root_node.has_solution
         assert get_first_solution_time(output_graph) == 3
         assert math.isclose(output_graph.root_node.data["retro_star_value"], 1.9)
-        assert math.isclose(output_graph.root_node.data["reaction_number"], 1.9)
+        assert math.isclose(output_graph.root_node.data["retro_star_reaction_number"], 1.9)
         assert math.isclose(output_graph.root_node.data["retro_star_min_cost"], 2.6)
         assert_retro_star_values_in_graph(output_graph, [1.9, 5.6, 2.6, 2.1, 5.7])
 
@@ -308,6 +308,6 @@ class TestRetroStar(BaseAlgorithmTest):
         assert output_graph.root_node.has_solution
         assert get_first_solution_time(output_graph) == 3
         assert math.isclose(output_graph.root_node.data["retro_star_value"], 1.6)
-        assert math.isclose(output_graph.root_node.data["reaction_number"], 1.6)
+        assert math.isclose(output_graph.root_node.data["retro_star_reaction_number"], 1.6)
         assert math.isclose(output_graph.root_node.data["retro_star_min_cost"], 1.6)
         assert_retro_star_values_in_graph(output_graph, [1.6, 2.6, 2.1])


### PR DESCRIPTION
Improved retro* implementation in several ways:

1. **Use better priority queue implementation**: the existing implementation did not track the set of nodes in the queue, and therefore could add a node to the queue multiple times. This generally caused the queue to be much larger than necessary, creating considerable slowdown in long searches. I fixed this by using a simple PQ implementation which allows for re-insertion.
2. **Track minimum cost route found so far**: this is essentially the "reaction number", but disregarding the search heuristic function. Tracking this could be useful for learning from self-play, and can be used to check whether the algorithm has found the minimum-cost route when the heuristic is admissible.
3. **Improve logging**: the queue size, graph size, and other details are logged in each iteration. I found this useful when running retro* for a large number of iterations.
4. **Fix edge case bug** where `reaction_number` depends on the `reaction_number_estimate` for all leaf nodes, including those which cannot be expanded (e.g. because they are too deep). This could cause the algorithm to pursue synthesis routes whose estimated cost can never be realized because one (or more) leaf nodes can never be expanded. I fixed this by only filling the `reaction_number_estimate` of nodes which can be expanded, and only including the `reaction_number_estimate` in the `reaction_number` calculation if it is present.