### PR TITLE
Add new compromise reaction class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Added
 
 - Add a new tutorial employing non-toy single-step models ([#54](https://github.com/microsoft/syntheseus/pull/54)) ([@kmaziarz])
+- Add new unified `Reaction` base class ([#63](https://github.com/microsoft/syntheseus/pull/63)) ([@austint])
 
 ### Fixed
 

--- a/syntheseus/interface/molecule.py
+++ b/syntheseus/interface/molecule.py
@@ -10,7 +10,6 @@ from rdkit import Chem
 from syntheseus.interface.typed_dict import TypedDict
 
 SMILES_SEPARATOR = "."
-REACTION_SEPARATOR = ">"
 
 
 class MoleculeMetaData(TypedDict, total=False):

--- a/syntheseus/interface/reaction.py
+++ b/syntheseus/interface/reaction.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from typing import Collection, Generic, Optional, TypeVar
+
+from syntheseus.interface.bag import Bag
+from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule
+from syntheseus.interface.typed_dict import TypedDict
+
+ReactantsType = TypeVar("ReactantsType")
+ProductType = TypeVar("ProductType")
+
+REACTION_SEPARATOR = ">"
+
+
+class ReactionMetaData(TypedDict, total=False):
+    """Class to add typing to optional meta-data fields for reactions."""
+
+    cost: float
+    template: str
+    source: str  # any explanation of the source of this reaction
+    probability: float  # probability for this reaction (e.g. from a model)
+    log_probability: float  # log probability for this reaction (should match log of above)
+    score: float  # any kind of score for this reaction (e.g. softmax value, probability)
+    confidence: float  # confidence (probability) that this reaction is possible
+    reaction_id: int  # template id or other kind of reaction id, if applicable
+    reaction_smiles: str  # reaction smiles for this reaction
+
+
+@dataclass(frozen=True, order=False)
+class Reaction(Generic[ReactantsType, ProductType]):
+    """General reaction class."""
+
+    # The molecule that the prediction is for and the predicted output:
+    reactants: ReactantsType = field(hash=True, compare=True)
+    product: ProductType = field(hash=True, compare=True)
+    identifier: Optional[str] = field(default=None, hash=True, compare=True)
+
+    # Dictionary to hold additional metadata.
+    metadata: ReactionMetaData = field(
+        default_factory=lambda: ReactionMetaData(),
+        hash=False,
+        compare=False,
+    )
+
+    @property
+    @abstractmethod
+    def reaction_smiles(self) -> str:
+        pass
+
+
+def combine_mols_to_string(mols: Collection[Molecule]) -> str:
+    """Produces a consistent string representation of a collection of molecules."""
+    return SMILES_SEPARATOR.join([mol.smiles for mol in sorted(mols)])
+
+
+def reaction_string(reactants_str: str, product_str: str) -> str:
+    """Produces a consistent string representation of a reaction."""
+    return f"{reactants_str}{2*REACTION_SEPARATOR}{product_str}"
+
+
+@dataclass(frozen=True, order=False)
+class MultiProductReaction(Reaction[Bag[Molecule], Bag[Molecule]]):
+    @property
+    def reaction_smiles(self) -> str:
+        return reaction_string(
+            reactants_str=combine_mols_to_string(self.reactants),
+            product_str=combine_mols_to_string(self.product),
+        )
+
+
+@dataclass(frozen=True, order=False)
+class SingleProductReaction(Reaction[Bag[Molecule], Molecule]):
+    @property
+    def reaction_smiles(self) -> str:
+        return reaction_string(
+            reactants_str=combine_mols_to_string(self.reactants), product_str=self.product.smiles
+        )

--- a/syntheseus/interface/reaction.py
+++ b/syntheseus/interface/reaction.py
@@ -49,6 +49,16 @@ class Reaction(Generic[ReactantsType, ProductType]):
     def reaction_smiles(self) -> str:
         pass
 
+    @property
+    @abstractmethod
+    def unique_reactants(self) -> Collection[Molecule]:
+        pass
+
+    @property
+    @abstractmethod
+    def unique_products(self) -> Collection[Molecule]:
+        pass
+
 
 def combine_mols_to_string(mols: Collection[Molecule]) -> str:
     """Produces a consistent string representation of a collection of molecules."""
@@ -69,6 +79,14 @@ class MultiProductReaction(Reaction[Bag[Molecule], Bag[Molecule]]):
             product_str=combine_mols_to_string(self.product),
         )
 
+    @property
+    def unique_reactants(self) -> Collection[Molecule]:
+        return set(self.reactants)
+
+    @property
+    def unique_products(self) -> Collection[Molecule]:
+        return set(self.product)
+
 
 @dataclass(frozen=True, order=False)
 class SingleProductReaction(Reaction[Bag[Molecule], Molecule]):
@@ -77,3 +95,11 @@ class SingleProductReaction(Reaction[Bag[Molecule], Molecule]):
         return reaction_string(
             reactants_str=combine_mols_to_string(self.reactants), product_str=self.product.smiles
         )
+
+    @property
+    def unique_reactants(self) -> Collection[Molecule]:
+        return set(self.reactants)
+
+    @property
+    def unique_products(self) -> Collection[Molecule]:
+        return {self.product}

--- a/syntheseus/reaction_prediction/data/reaction_sample.py
+++ b/syntheseus/reaction_prediction/data/reaction_sample.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Type, TypeVar
 
 from syntheseus.interface.bag import Bag
-from syntheseus.interface.molecule import REACTION_SEPARATOR, SMILES_SEPARATOR, Molecule
+from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule
+from syntheseus.interface.reaction import REACTION_SEPARATOR
 from syntheseus.reaction_prediction.chem.utils import (
     molecule_bag_to_smiles,
     remove_atom_mapping,

--- a/syntheseus/search/chem.py
+++ b/syntheseus/search/chem.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Optional
 
-from syntheseus.interface.molecule import REACTION_SEPARATOR, SMILES_SEPARATOR, Molecule
+from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule
+from syntheseus.interface.reaction import REACTION_SEPARATOR
 from syntheseus.interface.typed_dict import TypedDict
 
 

--- a/syntheseus/tests/interface/test_reaction.py
+++ b/syntheseus/tests/interface/test_reaction.py
@@ -1,0 +1,27 @@
+from syntheseus.interface.bag import Bag
+from syntheseus.interface.molecule import Molecule
+from syntheseus.interface.reaction import MultiProductReaction, SingleProductReaction
+
+# TODO(@austint): more tests will follow once this class is integrated into the library
+# because tests from prior reaction classes will be ported here
+
+
+def test_reaction_objects():
+    """Instantiate a `Reaction` object."""
+    C2 = Molecule(2 * "C")
+    C3 = Molecule(3 * "C")
+    C5 = Molecule(5 * "C")
+
+    # Single product reaction
+    rxn1 = SingleProductReaction(
+        reactants=Bag([C2, C3]),
+        product=C5,
+    )
+    assert rxn1.reaction_smiles == "CC.CCC>>CCCCC"
+
+    # Multi-product reaction
+    rxn2 = MultiProductReaction(
+        reactants=Bag([C5]),
+        product=Bag([C2, C3]),
+    )
+    assert rxn2.reaction_smiles == "CCCCC>>CC.CCC"


### PR DESCRIPTION
This PR adds a new compromise Reaction class in a new file: `syntheseus/interface/reaction.py`. The class has the features we discussed in #58 [^1]. The class also includes a basic test.

The new classes is not used anywhere at the moment[^2]. I will refactor the rest of the code to use it in another PR. I thought it would be test to propose the class in isolation first to avoid doing all the refactoring, then re-doing it if we decide to make additional changes.

[^1]: Except for the `unique_reactants` alias. After thinking about it a bit more, if users know to use `unique_reactants` then they could just as easily write `set(reactants)`.

[^2]: Except that I moved the `REACTION_SEPARATOR` constant to `reaction.py` and changed resulting imports. It seemed odd to have it in `molecule.py`