### PR TITLE
Integrate the Graph2Edits model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Integrate the Graph2Edits model ([#65](https://github.com/microsoft/syntheseus/pull/65)) ([@kmaziarz])
 - Add a new tutorial employing non-toy single-step models ([#54](https://github.com/microsoft/syntheseus/pull/54)) ([@kmaziarz])
 - Add new unified `Reaction` base class ([#63](https://github.com/microsoft/syntheseus/pull/63)) ([@austint])
 

--- a/docs/single_step.md
+++ b/docs/single_step.md
@@ -1,4 +1,4 @@
-Syntheseus currently supports 7 established single-step models.
+Syntheseus currently supports 8 established single-step models.
 
 For convenience, for each model we include a default checkpoint trained on USPTO-50K.
 If no checkpoint directory is provided during model loading, `syntheseus` will automatically download a default checkpoint and cache it on disk for future use.
@@ -9,6 +9,7 @@ See table below for the links to the default checkpoints.
 |----------------------------------------------------------------|--------|
 | [Chemformer](https://figshare.com/ndownloader/files/42009888)  | finetuned by us starting from checkpoint released by authors |
 | [GLN](https://figshare.com/ndownloader/files/42012720)         | released by authors |
+| [Graph2Edits](https://figshare.com/ndownloader/files/44194301) | released by authors |
 | [LocalRetro](https://figshare.com/ndownloader/files/42287319)  | trained by us |
 | [MEGAN](https://figshare.com/ndownloader/files/42012732)       | trained by us |
 | [MHNreact](https://figshare.com/ndownloader/files/42012777)    | trained by us |

--- a/docs/tutorials/quick_start.ipynb
+++ b/docs/tutorials/quick_start.ipynb
@@ -141,6 +141,7 @@
      "output_type": "stream",
      "text": [
       "Chemformer:  Cc1ccc(Br)cc1 + Cc1ccc(Br)cc1\n",
+      "Graph2Edits: Cc1ccc(Br)cc1 + Cc1ccc([Sn](C)(C)C)cc1\n",
       "LocalRetro:  Cc1ccc(B(O)O)cc1 + Cc1ccc(Br)cc1\n",
       "MEGAN:       Cc1ccc(Br)cc1 + Cc1ccc([Mg+])cc1\n",
       "MHNreact:    Cc1ccc(Br)cc1 + Cc1ccc([Mg+])cc1\n",
@@ -154,6 +155,7 @@
     "\n",
     "models = [\n",
     "    ChemformerModel(),\n",
+    "    Graph2EditsModel(),\n",
     "    LocalRetroModel(),\n",
     "    MEGANModel(),\n",
     "    MHNreactModel(),\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,13 @@ dev = [
   "pytest-cov",
   "pre-commit"
 ]
-chemformer = ["syntheseus-chemformer"]
-graph2edits = ["syntheseus-graph2edits"]
+chemformer = ["syntheseus-chemformer==0.1.1"]
+graph2edits = ["syntheseus-graph2edits==0.1.0"]
 local-retro = ["syntheseus-local-retro==0.4.0"]
-megan = ["syntheseus-megan"]
-mhn-react = ["syntheseus-mhnreact"]
-retro-knn = ["syntheseus-local-retro", "torch-scatter"]
-root-aligned = ["syntheseus-root-aligned"]
+megan = ["syntheseus-megan==0.1.0"]
+mhn-react = ["syntheseus-mhnreact==1.0.0"]
+retro-knn = ["syntheseus[local-retro]", "torch-scatter"]
+root-aligned = ["syntheseus-root-aligned==0.1.0"]
 all-single-step = [
   "syntheseus[chemformer,graph2edits,local-retro,megan,mhn-react,retro-knn,root-aligned]"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
 ]
 chemformer = ["syntheseus-chemformer"]
 graph2edits = ["syntheseus-graph2edits"]
-local-retro = ["syntheseus-local-retro"]
+local-retro = ["syntheseus-local-retro==0.4.0"]
 megan = ["syntheseus-megan"]
 mhn-react = ["syntheseus-mhnreact"]
 retro-knn = ["syntheseus-local-retro", "torch-scatter"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,14 @@ dev = [
   "pre-commit"
 ]
 chemformer = ["syntheseus-chemformer"]
+graph2edits = ["syntheseus-graph2edits"]
 local-retro = ["syntheseus-local-retro"]
 megan = ["syntheseus-megan"]
 mhn-react = ["syntheseus-mhnreact"]
 retro-knn = ["syntheseus-local-retro", "torch-scatter"]
 root-aligned = ["syntheseus-root-aligned"]
 all-single-step = [
-  "syntheseus[chemformer,local-retro,megan,mhn-react,retro-knn,root-aligned]"
+  "syntheseus[chemformer,graph2edits,local-retro,megan,mhn-react,retro-knn,root-aligned]"
 ]
 all = [
   "syntheseus[viz,dev,all-single-step]"

--- a/syntheseus/reaction_prediction/inference/__init__.py
+++ b/syntheseus/reaction_prediction/inference/__init__.py
@@ -1,5 +1,6 @@
 from syntheseus.reaction_prediction.inference.chemformer import ChemformerModel
 from syntheseus.reaction_prediction.inference.gln import GLNModel
+from syntheseus.reaction_prediction.inference.graph2edits import Graph2EditsModel
 from syntheseus.reaction_prediction.inference.local_retro import LocalRetroModel
 from syntheseus.reaction_prediction.inference.megan import MEGANModel
 from syntheseus.reaction_prediction.inference.mhnreact import MHNreactModel
@@ -9,6 +10,7 @@ from syntheseus.reaction_prediction.inference.root_aligned import RootAlignedMod
 __all__ = [
     "ChemformerModel",
     "GLNModel",
+    "Graph2EditsModel",
     "LocalRetroModel",
     "MEGANModel",
     "MHNreactModel",

--- a/syntheseus/reaction_prediction/inference/config.py
+++ b/syntheseus/reaction_prediction/inference/config.py
@@ -7,6 +7,7 @@ from omegaconf import MISSING
 from syntheseus.reaction_prediction.inference import (
     ChemformerModel,
     GLNModel,
+    Graph2EditsModel,
     LocalRetroModel,
     MEGANModel,
     MHNreactModel,
@@ -22,6 +23,7 @@ class ForwardModelClass(Enum):
 class BackwardModelClass(Enum):
     Chemformer = ChemformerModel
     GLN = GLNModel
+    Graph2Edits = Graph2EditsModel
     LocalRetro = LocalRetroModel
     MEGAN = MEGANModel
     MHNreact = MHNreactModel

--- a/syntheseus/reaction_prediction/inference/default_checkpoint_links.yml
+++ b/syntheseus/reaction_prediction/inference/default_checkpoint_links.yml
@@ -1,6 +1,7 @@
 backward:
   Chemformer: https://figshare.com/ndownloader/files/42009888
   GLN: https://figshare.com/ndownloader/files/42012720
+  Graph2Edits: https://figshare.com/ndownloader/files/44194301
   LocalRetro: https://figshare.com/ndownloader/files/42287319
   MEGAN: https://figshare.com/ndownloader/files/42012732
   MHNreact: https://figshare.com/ndownloader/files/42012777

--- a/syntheseus/reaction_prediction/inference/graph2edits.py
+++ b/syntheseus/reaction_prediction/inference/graph2edits.py
@@ -22,7 +22,7 @@ from syntheseus.reaction_prediction.utils.inference import (
     get_unique_file_in_dir,
     process_raw_smiles_outputs,
 )
-from syntheseus.reaction_prediction.utils.misc import remove_ambiguous_modules, suppress_outputs
+from syntheseus.reaction_prediction.utils.misc import suppress_outputs
 
 
 class Graph2EditsModel(ExternalBackwardReactionModel):
@@ -55,8 +55,6 @@ class Graph2EditsModel(ExternalBackwardReactionModel):
         self._max_edit_steps = max_edit_steps
 
         RDLogger.DisableLog("rdApp.*")
-
-        remove_ambiguous_modules(package_name="graph2edits")
 
     def get_parameters(self):
         return self.model.model.parameters()

--- a/syntheseus/reaction_prediction/inference/graph2edits.py
+++ b/syntheseus/reaction_prediction/inference/graph2edits.py
@@ -1,0 +1,99 @@
+"""Inference wrapper for the Graph2Edits model.
+
+Paper: https://www.nature.com/articles/s41467-023-38851-5
+Code: https://github.com/Jamson-Zhong/Graph2Edits
+
+The original Graph2Edits code is released under the MIT license.
+Parts of this file are based on code from the GitHub repository above.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Sequence
+
+from rdkit import Chem, RDLogger
+
+from syntheseus.interface.models import BackwardPrediction
+from syntheseus.interface.molecule import Molecule
+from syntheseus.reaction_prediction.inference.base import ExternalBackwardReactionModel
+from syntheseus.reaction_prediction.utils.inference import (
+    get_module_path,
+    get_unique_file_in_dir,
+    process_raw_smiles_outputs,
+)
+from syntheseus.reaction_prediction.utils.misc import suppress_outputs
+
+
+class Graph2EditsModel(ExternalBackwardReactionModel):
+    def __init__(self, *args, max_edit_steps: int = 9, **kwargs) -> None:
+        """Initializes the Graph2Edits model wrapper.
+
+        Assumed format of the model directory:
+        - `model_dir` contains the model checkpoint as the only `*.pt` file
+        """
+        super().__init__(*args, **kwargs)
+
+        import graph2edits
+        import torch
+
+        sys.path.insert(0, str(get_module_path(graph2edits)))
+
+        from graph2edits.models import BeamSearch, Graph2Edits
+
+        checkpoint = torch.load(
+            get_unique_file_in_dir(self.model_dir, pattern="*.pt"), map_location=self.device
+        )
+
+        model = Graph2Edits(**checkpoint["saveables"], device=self.device)
+        model.load_state_dict(checkpoint["state"])
+        model.to(self.device)
+        model.eval()
+
+        # We set the beam size to a placeholder value for now and override it in `__call__`.
+        self.model = BeamSearch(model=model, step_beam_size=10, beam_size=None, use_rxn_class=False)
+        self._max_edit_steps = max_edit_steps
+
+        RDLogger.DisableLog("rdApp.*")
+
+    def get_parameters(self):
+        return self.model.model.parameters()
+
+    def __call__(
+        self, inputs: list[Molecule], num_results: int
+    ) -> list[Sequence[BackwardPrediction]]:
+        import torch
+
+        self.model.beam_size = num_results
+
+        batch_predictions = []
+        for input in inputs:
+            # Copy the `rdkit` molecule as below we modify it in-place.
+            mol = Chem.Mol(input.rdkit_mol)
+
+            # Assign a dummy atom mapping as Graph2Edits depends on it. This has no connection to
+            # the ground-truth atom mapping, which we do not have access to.
+            for idx, atom in enumerate(mol.GetAtoms()):
+                atom.SetAtomMapNum(idx + 1)
+
+            with torch.no_grad(), suppress_outputs():
+                raw_results = self.model.run_search(
+                    prod_smi=Chem.MolToSmiles(mol), max_steps=self._max_edit_steps, rxn_class=None
+                )
+
+            # Errors are returned as a string "final_smi_unmapped"; we get rid of those here.
+            raw_results = [
+                raw_result
+                for raw_result in raw_results
+                if raw_result["final_smi"] != "final_smi_unmapped"
+            ]
+
+            batch_predictions.append(
+                process_raw_smiles_outputs(
+                    input=input,
+                    output_list=[raw_result["final_smi"] for raw_result in raw_results],
+                    kwargs_list=[{"probability": raw_result["prob"]} for raw_result in raw_results],
+                )
+            )
+
+        return batch_predictions

--- a/syntheseus/reaction_prediction/inference/graph2edits.py
+++ b/syntheseus/reaction_prediction/inference/graph2edits.py
@@ -22,7 +22,7 @@ from syntheseus.reaction_prediction.utils.inference import (
     get_unique_file_in_dir,
     process_raw_smiles_outputs,
 )
-from syntheseus.reaction_prediction.utils.misc import suppress_outputs
+from syntheseus.reaction_prediction.utils.misc import remove_ambiguous_modules, suppress_outputs
 
 
 class Graph2EditsModel(ExternalBackwardReactionModel):
@@ -55,6 +55,8 @@ class Graph2EditsModel(ExternalBackwardReactionModel):
         self._max_edit_steps = max_edit_steps
 
         RDLogger.DisableLog("rdApp.*")
+
+        remove_ambiguous_modules(package_name="graph2edits")
 
     def get_parameters(self):
         return self.model.model.parameters()

--- a/syntheseus/reaction_prediction/utils/misc.py
+++ b/syntheseus/reaction_prediction/utils/misc.py
@@ -2,7 +2,6 @@ import logging
 import multiprocessing
 import os
 import random
-import sys
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from dataclasses import fields, is_dataclass
 from itertools import islice
@@ -113,25 +112,3 @@ def parallelize(
 def cpu_count(default: int = 8) -> int:
     """Return the number of CPUs, fallback to `default` if it cannot be determined."""
     return os.cpu_count() or default
-
-
-def remove_ambiguous_modules(
-    package_name: str, extra_identifying_keywords: Optional[List[str]] = None
-) -> None:
-    """Remove from Python cache ambiguously named modules coming from a given package.
-
-    Args:
-        package_name: Name of the package to deal with.
-        extra_identifying_keywords: Extra keywords that are specific enough to the package in
-            question. For a module to be kept its name must contain either the package name or at
-            least one of the keywords.
-    """
-    keywords = [package_name] + (extra_identifying_keywords or [])
-
-    ambiguous_module_names: List[str] = []
-    for module_name, module in sys.modules.items():
-        if package_name in str(module) and not any(keyword in module_name for keyword in keywords):
-            ambiguous_module_names.append(module_name)
-
-    for module_name in ambiguous_module_names:
-        del sys.modules[module_name]

--- a/syntheseus/tests/reaction_prediction/inference/test_models.py
+++ b/syntheseus/tests/reaction_prediction/inference/test_models.py
@@ -45,7 +45,8 @@ pytestmark = pytest.mark.skipif(
         MHNreactModel,
         RetroKNNModel,
         RootAlignedModel,
-    ],
+    ]
+    * 2,
 )
 def model(request) -> ExternalBackwardReactionModel:
     model_cls = request.param

--- a/syntheseus/tests/reaction_prediction/inference/test_models.py
+++ b/syntheseus/tests/reaction_prediction/inference/test_models.py
@@ -4,6 +4,7 @@ from syntheseus.interface.bag import Bag
 from syntheseus.interface.molecule import Molecule
 from syntheseus.reaction_prediction.inference import (
     ChemformerModel,
+    Graph2EditsModel,
     LocalRetroModel,
     MEGANModel,
     MHNreactModel,
@@ -18,6 +19,7 @@ try:
     # the tests will fail; nevertheless the check below is good enough for our usecase.
 
     import chemformer  # noqa: F401
+    import graph2edits  # noqa: F401
     import local_retro  # noqa: F401
     import megan  # noqa: F401
     import mhnreact  # noqa: F401
@@ -37,6 +39,7 @@ pytestmark = pytest.mark.skipif(
     scope="module",
     params=[
         ChemformerModel,
+        Graph2EditsModel,
         LocalRetroModel,
         MEGANModel,
         MHNreactModel,


### PR DESCRIPTION
This PR integrates Graph2Edits - a recently proposed model class which shows promising results on USPTO-50K. It includes a full model wrapper with a default checkpoint, as well as edits to docs and tutorials to mention the new model type.

Testing the integration uncovered a potential problem with some of the model classes: as the underlying repositories are often not set up for installability and use relative imports, creating LocalRetro loads a Python module called `models`; when one then tries to create Graph2Edits which also contains a module with that name, Python looks up the module in `sys.modules` rather than re-importing it from the new location. This leads to errors if the two models are used together, which was caught by our models test. To fix this, I refactored LocalRetro to place all modules under a top-level directory named `local_retro`, and released the updated code as a new version of `syntheseus-local-retro` on PyPI.

Finally, as import-related errors could potentially depend on the _order_ in which the two conflicting models are used, I also changed the models test to test each model type _twice_, covering _each pair of models in both orders_. Note that this does not affect running time, as most of the time is spent downloading model weights, and so re-testing a model again requires negligible extra time.