### PR TITLE
Fix small issues in the integration of Graph2Edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Integrate the Graph2Edits model ([#65](https://github.com/microsoft/syntheseus/pull/65)) ([@kmaziarz])
+- Integrate the Graph2Edits model ([#65](https://github.com/microsoft/syntheseus/pull/65), [#66](https://github.com/microsoft/syntheseus/pull/66)) ([@kmaziarz])
 - Add a new tutorial employing non-toy single-step models ([#54](https://github.com/microsoft/syntheseus/pull/54)) ([@kmaziarz])
 - Add new unified `Reaction` base class ([#63](https://github.com/microsoft/syntheseus/pull/63)) ([@austint])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
   "pre-commit"
 ]
 chemformer = ["syntheseus-chemformer==0.1.1"]
-graph2edits = ["syntheseus-graph2edits==0.1.0"]
+graph2edits = ["syntheseus-graph2edits==0.2.0"]
 local-retro = ["syntheseus-local-retro==0.4.0"]
 megan = ["syntheseus-megan==0.1.0"]
 mhn-react = ["syntheseus-mhnreact==1.0.0"]

--- a/syntheseus/reaction_prediction/inference/graph2edits.py
+++ b/syntheseus/reaction_prediction/inference/graph2edits.py
@@ -77,9 +77,15 @@ class Graph2EditsModel(ExternalBackwardReactionModel):
                 atom.SetAtomMapNum(idx + 1)
 
             with torch.no_grad(), suppress_outputs():
-                raw_results = self.model.run_search(
-                    prod_smi=Chem.MolToSmiles(mol), max_steps=self._max_edit_steps, rxn_class=None
-                )
+                try:
+                    raw_results = self.model.run_search(
+                        prod_smi=Chem.MolToSmiles(mol),
+                        max_steps=self._max_edit_steps,
+                        rxn_class=None,
+                    )
+                except IndexError:
+                    # This can happen in some rare edge cases (e.g. "OBr").
+                    raw_results = []
 
             # Errors are returned as a string "final_smi_unmapped"; we get rid of those here.
             raw_results = [


### PR DESCRIPTION
The recent integration of Graph2Edits in #65 missed two caveats:
- The `syntheseus-graph2edits` package did not specify that it depends on `joblib`, which was missed in initial testing as it's a rather common dependency that is pulled in by e.g. LocalRetro, so this issue only arises when Graph2Edits is used in isolation. I pushed version `0.2.0` that specifies the dependency and in this PR I bump the version requirement in syntheseus.
- In very rare cases (e.g. for the molecule with SMILES "OBr"), the Graph2Edits code fails with an unclear `IndexError`. This was not seen during evaluation on USPTO-50K, but happens occasionally during search. As these cases are very rare and there is no obvious fix, I resort to simply catching the exception and returning no proposed reactions in this case.