### PR TITLE
Free extra disk space for the models tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         shell: bash -l {0}
     name: test-models
     steps:
+    - name: Free extra disk space
+      uses: jlumbroso/free-disk-space@main
     - uses: actions/checkout@v3
     - uses: conda-incubator/setup-miniconda@v2
       with:


### PR DESCRIPTION
Our models tests download the default single-step model weights, which takes ~10GB of disk space. This is roughly half of the space that is normally available on GitHub Actions runners, and (taken together with all the packages we install) it recently started hitting the disk space limit.

This PR adds an extra step based on [jlumbroso/free-disk-space](https://github.com/jlumbroso/free-disk-space) to the models tests. This step frees extra disk space by deleting large pre-existing files present on the default image (e.g. packages related to android, haskell, .NET, etc) as well as optimizing how the disk is partitioned. This saves ~24 GB of disk space (see logs in [this job](https://github.com/microsoft/syntheseus/actions/runs/7799211295/job/21269518861)), more than doubling what we had previously.