### PR TITLE
Make the data loader class work with relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Get all single-step models to work on CPU ([#57](https://github.com/microsoft/syntheseus/pull/57)) ([@kmaziarz])
+- Make the data loader class work with relative paths ([#69](https://github.com/microsoft/syntheseus/pull/69)) ([@kmaziarz])
 
 ## [0.3.0] - 2023-12-19
 


### PR DESCRIPTION
There is a bug in the `DiskReactionDataset` class (introduced several months ago in PR #33) that makes the class (and, by extension, the single-step evaluation script) only work when given an _absolute_ path to the data, but not if the path is _relative_ (thanks to Aleksei Kornev for finding this!). The bug is caused by the path to data files being constructed as `data_dir / filepath` where `filepath` is already a full path (and not a filename); this happens to work with absolute paths as in that case `pathlib` ignores the first argument to `/` and just returns the second argument. We did not catch this earlier as all of our experiments and unit tests used absolute paths.

This PR fixes the bug, and also extends the dataset test to verify that things work both when using absolute and relative paths (and this test indeed fails if the fix is not included).