### PR TITLE
Rename value function to search heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
 - Improve efficiency and logging of retro* algorithm ([#62](https://github.com/microsoft/syntheseus/pull/62)) ([@austint])
+- Replace the term "value function" with "search heuristic" when appropriate ([#70](https://github.com/microsoft/syntheseus/pull/70)) ([@austint])
 - Remove `PredictionList` objects, replacing them with `Sequence[Prediction]` ([#61](https://github.com/microsoft/syntheseus/pull/61)) ([@austint])
 
 ### Added

--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -56,8 +56,8 @@ logger = logging.getLogger(__file__)
 class RetroStarConfig:
     max_expansion_depth: int = 10
 
-    value_function_class: str = "ConstantNodeEvaluator"
-    value_function_kwargs: Dict[str, Any] = field(default_factory=lambda: {"constant": 0.0})
+    search_heuristic_class: str = "ConstantNodeEvaluator"
+    search_heuristic_kwargs: Dict[str, Any] = field(default_factory=lambda: {"constant": 0.0})
 
     and_node_cost_fn_class: str = "ReactionModelLogProbCost"
     and_node_cost_fn_kwargs: Dict[str, Any] = field(default_factory=dict)
@@ -67,8 +67,8 @@ class RetroStarConfig:
 class MCTSConfig:
     max_expansion_depth: int = 20
 
-    value_function_class: str = "ConstantNodeEvaluator"
-    value_function_kwargs: Dict[str, Any] = field(default_factory=lambda: {"constant": 0.5})
+    search_heuristic_class: str = "ConstantNodeEvaluator"
+    search_heuristic_kwargs: Dict[str, Any] = field(default_factory=lambda: {"constant": 0.5})
 
     reward_function_class: str = "HasSolutionValueFunction"
     reward_function_kwargs: Dict[str, Any] = field(default_factory=dict)
@@ -84,11 +84,11 @@ class MCTSConfig:
 class PDVNConfig:
     max_expansion_depth: int = 10
 
-    value_function_syn_class: str = "ConstantNodeEvaluator"
-    value_function_syn_kwargs: Dict[str, Any] = field(default_factory=lambda: {"constant": 0.5})
+    search_heuristic_syn_class: str = "ConstantNodeEvaluator"
+    search_heuristic_syn_kwargs: Dict[str, Any] = field(default_factory=lambda: {"constant": 0.5})
 
-    value_function_cost_class: str = "ConstantNodeEvaluator"
-    value_function_cost_kwargs: Dict[str, Any] = field(default_factory=lambda: {"constant": 0.0})
+    search_heuristic_cost_class: str = "ConstantNodeEvaluator"
+    search_heuristic_cost_kwargs: Dict[str, Any] = field(default_factory=lambda: {"constant": 0.0})
 
     and_node_cost_fn_class: str = "ConstantNodeEvaluator"
     and_node_cost_fn_kwargs: Dict[str, Any] = field(default_factory=lambda: {"constant": 0.1})
@@ -207,13 +207,13 @@ def run_from_config(config: SearchConfig) -> Path:
     alg: Any = None
     if config.search_algorithm == "retro_star":
         alg_kwargs.update(cast(Dict[str, Any], OmegaConf.to_container(config.retro_star_config)))
-        build_node_evaluator("value_function")
+        build_node_evaluator("search_heuristic")
         build_node_evaluator("and_node_cost_fn")
 
         alg = RetroStarSearch(**alg_kwargs)
     elif config.search_algorithm == "mcts":
         alg_kwargs.update(cast(Dict[str, Any], OmegaConf.to_container(config.mcts_config)))
-        build_node_evaluator("value_function")
+        build_node_evaluator("search_heuristic")
         build_node_evaluator("reward_function")
         build_node_evaluator("policy")
 
@@ -223,8 +223,8 @@ def run_from_config(config: SearchConfig) -> Path:
         alg = MolSetMCTS(**alg_kwargs)
     elif config.search_algorithm == "pdvn":
         alg_kwargs.update(cast(Dict[str, Any], OmegaConf.to_container(config.pdvn_config)))
-        build_node_evaluator("value_function_syn")
-        build_node_evaluator("value_function_cost")
+        build_node_evaluator("search_heuristic_syn")
+        build_node_evaluator("search_heuristic_cost")
         build_node_evaluator("and_node_cost_fn")
         build_node_evaluator("policy")
 

--- a/syntheseus/cli/search_config.yml
+++ b/syntheseus/cli/search_config.yml
@@ -3,19 +3,19 @@ mcts:
     bound_constant: 1
     policy_kwargs:
       temperature: 8.0
-    value_function_kwargs:
+    search_heuristic_kwargs:
       constant: 0.75
   GLN:
     bound_constant: 100
     policy_kwargs:
       temperature: 4.0
-    value_function_kwargs:
+    search_heuristic_kwargs:
       constant: 0.5
   LocalRetro:
     bound_constant: 1
     policy_kwargs:
       temperature: 4.0
-    value_function_kwargs:
+    search_heuristic_kwargs:
       constant: 0.5
   MEGAN:
     bound_constant: 1
@@ -23,19 +23,19 @@ mcts:
       clip_probability_max: 0.9999
       clip_probability_min: 1.0e-05
       temperature: 2.0
-    value_function_kwargs:
+    search_heuristic_kwargs:
       constant: 0.75
   MHNreact:
     bound_constant: 1
     policy_kwargs:
       temperature: 8.0
-    value_function_kwargs:
+    search_heuristic_kwargs:
       constant: 0.5
   RetroKNN:
     bound_constant: 1
     policy_kwargs:
       temperature: 8.0
-    value_function_kwargs:
+    search_heuristic_kwargs:
       constant: 0.75
   RootAligned:
     bound_constant: 10
@@ -43,7 +43,7 @@ mcts:
       clip_probability_max: 0.999
       clip_probability_min: 1.0e-05
       temperature: 8.0
-    value_function_kwargs:
+    search_heuristic_kwargs:
       constant: 0.5
 retro_star:
   MEGAN:

--- a/syntheseus/search/algorithms/best_first/retro_star.py
+++ b/syntheseus/search/algorithms/best_first/retro_star.py
@@ -13,7 +13,7 @@ from typing import (
 
 from syntheseus.search.algorithms.base import AndOrSearchAlgorithm
 from syntheseus.search.algorithms.best_first.base import GeneralBestFirstSearch
-from syntheseus.search.algorithms.mixins import ValueFunctionMixin
+from syntheseus.search.algorithms.mixins import SearchHeuristicMixin
 from syntheseus.search.graph.and_or import ANDOR_NODE, AndNode, AndOrGraph, OrNode
 from syntheseus.search.graph.message_passing import run_message_passing
 from syntheseus.search.node_evaluation.base import BaseNodeEvaluator, NoCacheNodeEvaluator
@@ -31,7 +31,7 @@ class MolIsPurchasableCost(NoCacheNodeEvaluator[OrNode]):
 class RetroStarSearch(
     AndOrSearchAlgorithm[int],
     GeneralBestFirstSearch[AndOrGraph],
-    ValueFunctionMixin[OrNode],
+    SearchHeuristicMixin[OrNode],
 ):
     def __init__(
         self,
@@ -48,15 +48,15 @@ class RetroStarSearch(
 
     @property
     def reaction_number_estimator(self) -> BaseNodeEvaluator[OrNode]:
-        """Alias for value function (they use this term in the paper)"""
-        return self.value_function
+        """Alias for search heuristic / value function (they use this term in the paper)"""
+        return self.search_heuristic
 
     def priority_function(self, node: ANDOR_NODE, _: AndNode) -> float:  # type: ignore[override]
         return node.data["retro_star_value"]
 
     def setup(self, graph: AndOrGraph) -> None:
         # If there is only one node, set its reaction number estimate to 0.
-        # This saves a call to the value function
+        # This saves a call to the search heuristic
         if len(graph) == 1:
             graph.root_node.data.setdefault("reaction_number_estimate", 0.0)
 

--- a/syntheseus/search/algorithms/mixins.py
+++ b/syntheseus/search/algorithms/mixins.py
@@ -9,17 +9,17 @@ from syntheseus.search.node_evaluation import BaseNodeEvaluator
 NodeType = TypeVar("NodeType", bound=BaseGraphNode)
 
 
-class ValueFunctionMixin(SearchAlgorithm, Generic[NodeType]):
-    def __init__(self, *args, value_function: BaseNodeEvaluator[NodeType], **kwargs):
+class SearchHeuristicMixin(SearchAlgorithm, Generic[NodeType]):
+    def __init__(self, *args, search_heuristic: BaseNodeEvaluator[NodeType], **kwargs):
         super().__init__(*args, **kwargs)
-        self.value_function = value_function
+        self.search_heuristic = search_heuristic
 
     def set_node_values(self, nodes, graph):
         output_nodes = super().set_node_values(nodes, graph)
         for node in output_nodes:
-            node.data.setdefault("num_calls_value_function", self.value_function.num_calls)
+            node.data.setdefault("num_calls_search_heuristic", self.search_heuristic.num_calls)
         return output_nodes
 
     def reset(self) -> None:
         super().reset()
-        self.value_function.reset()
+        self.search_heuristic.reset()

--- a/syntheseus/search/algorithms/pdvn.py
+++ b/syntheseus/search/algorithms/pdvn.py
@@ -63,21 +63,21 @@ class PDVN_MCTS(BaseMCTS[AndOrGraph, OrNode, AndNode], AndOrSearchAlgorithm[int]
     def __init__(
         self,
         c_dead: float,  # cost of a dead end (equation 1 of Liu et al 2023)
-        value_function_syn: BaseNodeEvaluator[OrNode],
-        value_function_cost: BaseNodeEvaluator[OrNode],
+        search_heuristic_syn: BaseNodeEvaluator[OrNode],
+        search_heuristic_cost: BaseNodeEvaluator[OrNode],
         and_node_cost_fn: BaseNodeEvaluator[AndNode],
         bound_function: Callable[[AndNode], AndOrGraph] = pucb_bound,  # type: ignore[assignment]  # sloppy typing for bounds
         **kwargs,
     ):
         super().__init__(
             bound_function=bound_function,  # type: ignore[arg-type]  # sloppy typing for bounds
-            value_function=value_function_cost,
+            search_heuristic=search_heuristic_cost,
             reward_function=None,  # type: ignore[arg-type]  # reward function is not used for PDVN MCTS
             **kwargs,
         )
         self.c_dead = c_dead
-        self.value_function_syn = value_function_syn
-        self.value_function_cost = value_function_cost
+        self.search_heuristic_syn = search_heuristic_syn
+        self.search_heuristic_cost = search_heuristic_cost
         self.and_node_cost_fn = and_node_cost_fn
         assert self.policy is not None, "PDVN_MCTS requires a policy to be specified."
 
@@ -178,8 +178,8 @@ class PDVN_MCTS(BaseMCTS[AndOrGraph, OrNode, AndNode], AndOrSearchAlgorithm[int]
             reward_syn = float(purchasable)
             reward_cost = 0.0 if purchasable else self.c_dead
         else:
-            reward_syn = self.value_function_syn([node], graph)[0]
-            reward_cost = self.value_function_cost([node], graph)[0]
+            reward_syn = self.search_heuristic_syn([node], graph)[0]
+            reward_cost = self.search_heuristic_cost([node], graph)[0]
 
         return reward_syn, reward_cost
 

--- a/syntheseus/search/graph/node.py
+++ b/syntheseus/search/graph/node.py
@@ -15,8 +15,8 @@ class _NodeData_Time(TypedDict, total=False):
     # How many times has the rxn model been called when this node was created?
     num_calls_rxn_model: int
 
-    # How many times has the value function been called when this node was created?
-    num_calls_value_function: int
+    # How many times has the search heuristic been called when this node was created?
+    num_calls_search_heuristic: int
 
 
 class _NodeData_Algorithms(TypedDict, total=False):

--- a/syntheseus/search/graph/standardization.py
+++ b/syntheseus/search/graph/standardization.py
@@ -80,7 +80,7 @@ def _unique_node_andor_from_andor(
 
         # Set time attributes
         node_in_new_graph.creation_time = min(node_in_new_graph.creation_time, node.creation_time)
-        for k in ["num_calls_rxn_model", "num_calls_value_function"]:
+        for k in ["num_calls_rxn_model", "num_calls_search_heuristic"]:
             if k in node.data:
                 # doesn't understand typeddict
                 node_in_new_graph.data[k] = min(  # type: ignore[literal-required]
@@ -118,7 +118,7 @@ def _unique_node_andor_from_molset(
         for mol in node.mols:
             mol_to_node[mol].creation_time = min(mol_to_node[mol].creation_time, node.creation_time)
 
-            for k in ["num_calls_rxn_model", "num_calls_value_function"]:
+            for k in ["num_calls_rxn_model", "num_calls_search_heuristic"]:
                 if k in node.data:
                     mol_to_node[mol].data[k] = min(  # type: ignore[literal-required]
                         cast(int, mol_to_node[mol].data.get(k, math.inf)),
@@ -135,7 +135,7 @@ def _unique_node_andor_from_molset(
             if c_time < rxn_to_node[rxn].creation_time:
                 rxn_to_node[rxn].creation_time = c_time
 
-            for k in ["num_calls_rxn_model", "num_calls_value_function"]:
+            for k in ["num_calls_rxn_model", "num_calls_search_heuristic"]:
                 if k in node.data:
                     cand_time = max(node.data[k], parent.data[k])  # type: ignore[literal-required]
                     rxn_to_node[rxn].data[k] = min(  # type: ignore[literal-required]

--- a/syntheseus/search/node_evaluation/base.py
+++ b/syntheseus/search/node_evaluation/base.py
@@ -15,7 +15,7 @@ NodeType = TypeVar("NodeType", bound=BaseGraphNode)
 class BaseNodeEvaluator(Generic[NodeType], abc.ABC):
     """
     Parent class for functions which assign values to nodes.
-    This includes value functions, policies, reward functions, etc.
+    This includes search heuristics, policies, reward functions, etc.
 
     Also counts number of times it has been called.
     However, unlike for reaction models caching is not implemented by default.

--- a/syntheseus/tests/search/algorithms/test_best_first.py
+++ b/syntheseus/tests/search/algorithms/test_best_first.py
@@ -83,7 +83,7 @@ class TestRetroStar(BaseAlgorithmTest):
         # Return retro*0 with a constant unit cost for each reaction
         kwargs.setdefault("and_node_cost_fn", ConstantNodeEvaluator(1.0))
         kwargs.setdefault("or_node_cost_fn", MolIsPurchasableCost())
-        kwargs.setdefault("value_function", ConstantNodeEvaluator(0.0))
+        kwargs.setdefault("search_heuristic", ConstantNodeEvaluator(0.0))
         return RetroStarSearch(**kwargs)
 
     def test_by_hand_step1(
@@ -111,7 +111,7 @@ class TestRetroStar(BaseAlgorithmTest):
         (c=Z) denotes the cost cost of the reaction Z
         """
         output_graph = self.run_alg_for_n_iterations(
-            retrosynthesis_task5, 1, and_node_cost_fn=rxn_cost_fn, value_function=mol_value_fn
+            retrosynthesis_task5, 1, and_node_cost_fn=rxn_cost_fn, search_heuristic=mol_value_fn
         )
         assert output_graph.reaction_smiles_counter() == {  # type: ignore  # unsure about rxn_counter
             "C>>CC": 1,
@@ -146,7 +146,7 @@ class TestRetroStar(BaseAlgorithmTest):
         (disclaimer: because the tree is large it is possible that some hand-calculated values are wrong)
         """
         output_graph = self.run_alg_for_n_iterations(
-            retrosynthesis_task5, 2, and_node_cost_fn=rxn_cost_fn, value_function=mol_value_fn
+            retrosynthesis_task5, 2, and_node_cost_fn=rxn_cost_fn, search_heuristic=mol_value_fn
         )
         assert output_graph.reaction_smiles_counter() == {  # type: ignore  # unsure about rxn_counter
             "C>>CC": 1,
@@ -189,7 +189,7 @@ class TestRetroStar(BaseAlgorithmTest):
         (disclaimer: because the tree is large it is possible that some hand-calculated values are wrong)
         """
         output_graph = self.run_alg_for_n_iterations(
-            retrosynthesis_task5, 3, and_node_cost_fn=rxn_cost_fn, value_function=mol_value_fn
+            retrosynthesis_task5, 3, and_node_cost_fn=rxn_cost_fn, search_heuristic=mol_value_fn
         )
         assert output_graph.reaction_smiles_counter() == {  # type: ignore  # unsure about rxn_counter
             "C>>CC": 1,
@@ -236,7 +236,7 @@ class TestRetroStar(BaseAlgorithmTest):
         (disclaimer: because the tree is large it is possible that some hand-calculated values are wrong)
         """
         output_graph = self.run_alg_for_n_iterations(
-            retrosynthesis_task5, 4, and_node_cost_fn=rxn_cost_fn, value_function=mol_value_fn
+            retrosynthesis_task5, 4, and_node_cost_fn=rxn_cost_fn, search_heuristic=mol_value_fn
         )
         assert output_graph.reaction_smiles_counter() == {  # type: ignore  # unsure about rxn_counter
             "C>>CC": 1,
@@ -284,7 +284,7 @@ class TestRetroStar(BaseAlgorithmTest):
         (disclaimer: because the tree is large it is possible that some hand-calculated values are wrong)
         """
         output_graph = self.run_alg_for_n_iterations(
-            retrosynthesis_task5, 5, and_node_cost_fn=rxn_cost_fn, value_function=mol_value_fn
+            retrosynthesis_task5, 5, and_node_cost_fn=rxn_cost_fn, search_heuristic=mol_value_fn
         )
         assert output_graph.reaction_smiles_counter() == {  # type: ignore  # unsure about rxn_counter
             "C>>CC": 1,

--- a/syntheseus/tests/search/algorithms/test_mcts.py
+++ b/syntheseus/tests/search/algorithms/test_mcts.py
@@ -103,13 +103,13 @@ class TestMolSetMCTS(BaseAlgorithmTest):
     def setup_algorithm(
         self,
         reward_function=None,
-        value_function=None,
+        search_heuristic=None,
         bound_constant: float = 1e4,  # high default to ensure lots of exploring
         **kwargs,
     ) -> MolSetMCTS:
         return MolSetMCTS(
             reward_function=reward_function or HasSolutionValueFunction(),
-            value_function=value_function or ConstantNodeEvaluator(0.5),
+            search_heuristic=search_heuristic or ConstantNodeEvaluator(0.5),
             bound_constant=bound_constant,
             random_state=random.Random(42),  # control random seed
             **kwargs,
@@ -132,7 +132,7 @@ class TestMolSetMCTS(BaseAlgorithmTest):
         output_graph = self.run_alg_for_n_iterations(
             retrosynthesis_task5,
             1,
-            value_function=value_fn,
+            search_heuristic=value_fn,
             bound_constant=HAND_EXAMPLE_BOUND_CONSTANT,
         )
         assert not output_graph.root_node.has_solution  # should not be solved yet
@@ -152,7 +152,7 @@ class TestMolSetMCTS(BaseAlgorithmTest):
         output_graph = self.run_alg_for_n_iterations(
             retrosynthesis_task5,
             3,
-            value_function=value_fn,
+            search_heuristic=value_fn,
             bound_constant=HAND_EXAMPLE_BOUND_CONSTANT,
         )
         assert not output_graph.root_node.has_solution  # should not be solved yet
@@ -175,7 +175,7 @@ class TestMolSetMCTS(BaseAlgorithmTest):
         output_graph = self.run_alg_for_n_iterations(
             retrosynthesis_task5,
             4,
-            value_function=value_fn,
+            search_heuristic=value_fn,
             bound_constant=HAND_EXAMPLE_BOUND_CONSTANT,
         )
         assert len(output_graph) == 8
@@ -198,7 +198,7 @@ class TestMolSetMCTS(BaseAlgorithmTest):
         output_graph = self.run_alg_for_n_iterations(
             retrosynthesis_task5,
             5,
-            value_function=value_fn,
+            search_heuristic=value_fn,
             bound_constant=HAND_EXAMPLE_BOUND_CONSTANT,
         )
         assert len(output_graph) == 10
@@ -227,7 +227,7 @@ class TestMolSetMCTS(BaseAlgorithmTest):
         output_graph = self.run_alg_for_n_iterations(
             retrosynthesis_task5,
             4 * n - 1,
-            value_function=value_fn,
+            search_heuristic=value_fn,
             min_num_visit_to_expand=n,
             bound_constant=1e3,  # higher constant so that rewards don't matter
         )
@@ -252,7 +252,7 @@ class TestMolSetMCTS(BaseAlgorithmTest):
             self.run_alg_for_n_iterations(
                 retrosynthesis_task5,
                 10,
-                value_function=value_fn,
+                search_heuristic=value_fn,
                 bound_function=pucb_bound,
             )
 
@@ -289,7 +289,7 @@ class TestMolSetMCTS(BaseAlgorithmTest):
         output_graph = self.run_alg_for_n_iterations(
             retrosynthesis_task5,
             50,
-            value_function=value_fn,
+            search_heuristic=value_fn,
             bound_function=pucb_bound,
             policy=policy,
             bound_constant=10.0,

--- a/syntheseus/tests/search/algorithms/test_pdvn.py
+++ b/syntheseus/tests/search/algorithms/test_pdvn.py
@@ -78,8 +78,8 @@ rxns_step5 = rxns_step4 + [
 class TestPDVN_MCTS(BaseAlgorithmTest):
     def setup_algorithm(self, **kwargs) -> PDVN_MCTS:
         kwargs.setdefault("c_dead", 10.0)
-        kwargs.setdefault("value_function_syn", ConstantNodeEvaluator(0.8))
-        kwargs.setdefault("value_function_cost", ConstantNodeEvaluator(2.0))
+        kwargs.setdefault("search_heuristic_syn", ConstantNodeEvaluator(0.8))
+        kwargs.setdefault("search_heuristic_cost", ConstantNodeEvaluator(2.0))
         kwargs.setdefault("policy", ConstantNodeEvaluator(1.0))
         kwargs.setdefault("and_node_cost_fn", ConstantNodeEvaluator(1.0))
         kwargs.setdefault("bound_constant", 1e4)
@@ -112,8 +112,8 @@ class TestPDVN_MCTS(BaseAlgorithmTest):
             retrosynthesis_task5,
             1,
             policy=policy,
-            value_function_syn=mol_syn_estimate,
-            value_function_cost=mol_cost_estimate,
+            search_heuristic_syn=mol_syn_estimate,
+            search_heuristic_cost=mol_cost_estimate,
         )
         assert output_graph.reaction_smiles_counter() == Counter(rxns_step1)  # type: ignore[attr-defined]
 
@@ -149,7 +149,7 @@ class TestPDVN_MCTS(BaseAlgorithmTest):
         r"""
         Continuation of test above.
 
-        In the second iteration the value function for CS should be evaluated,
+        In the second iteration the search heuristic for CS should be evaluated,
         and in the third iteration CO should be expanded and the OO node visited.
 
         The tree should have the following structure:
@@ -166,8 +166,8 @@ class TestPDVN_MCTS(BaseAlgorithmTest):
             retrosynthesis_task5,
             3,
             policy=policy,
-            value_function_syn=mol_syn_estimate,
-            value_function_cost=mol_cost_estimate,
+            search_heuristic_syn=mol_syn_estimate,
+            search_heuristic_cost=mol_cost_estimate,
         )
         assert output_graph.reaction_smiles_counter() == Counter(rxns_step2)  # type: ignore[attr-defined]
 
@@ -205,7 +205,7 @@ class TestPDVN_MCTS(BaseAlgorithmTest):
         r"""
         Continuation of test above.
 
-        In the fourth iteration the value function for C should be evaluated,
+        In the fourth iteration the search heuristic for C should be evaluated,
         and in the fifth iteration OO should be expanded.
 
         The tree should have the following structure:
@@ -226,8 +226,8 @@ class TestPDVN_MCTS(BaseAlgorithmTest):
             retrosynthesis_task5,
             5,
             policy=policy,
-            value_function_syn=mol_syn_estimate,
-            value_function_cost=mol_cost_estimate,
+            search_heuristic_syn=mol_syn_estimate,
+            search_heuristic_cost=mol_cost_estimate,
         )
         assert output_graph.reaction_smiles_counter() == Counter(rxns_step3)  # type: ignore[attr-defined]
 
@@ -274,8 +274,8 @@ class TestPDVN_MCTS(BaseAlgorithmTest):
             retrosynthesis_task5,
             6,
             policy=policy,
-            value_function_syn=mol_syn_estimate,
-            value_function_cost=mol_cost_estimate,
+            search_heuristic_syn=mol_syn_estimate,
+            search_heuristic_cost=mol_cost_estimate,
         )
         assert output_graph.reaction_smiles_counter() == Counter(rxns_step4)  # type: ignore[attr-defined]
 
@@ -293,7 +293,7 @@ class TestPDVN_MCTS(BaseAlgorithmTest):
         r"""
         Continuation of test above.
 
-        For iterations 7-9 the value function of various other nodes will be evaluated
+        For iterations 7-9 the search heuristic of various other nodes will be evaluated
         without expansion. Then, on iteration 10 "C" will be expanded,
         leading to a new solution (O -> C).
 
@@ -315,8 +315,8 @@ class TestPDVN_MCTS(BaseAlgorithmTest):
             retrosynthesis_task5,
             10,
             policy=policy,
-            value_function_syn=mol_syn_estimate,
-            value_function_cost=mol_cost_estimate,
+            search_heuristic_syn=mol_syn_estimate,
+            search_heuristic_cost=mol_cost_estimate,
         )
         assert output_graph.reaction_smiles_counter() == Counter(rxns_step5)  # type: ignore[attr-defined]
 
@@ -352,8 +352,8 @@ class TestPDVN_MCTS(BaseAlgorithmTest):
             retrosynthesis_task5,
             1_000,
             policy=policy,
-            value_function_syn=mol_syn_estimate,
-            value_function_cost=mol_cost_estimate,
+            search_heuristic_syn=mol_syn_estimate,
+            search_heuristic_cost=mol_cost_estimate,
         )
 
         # Check training data is correct

--- a/tutorials/search/2a- advanced algorithms on PaRoutes.ipynb
+++ b/tutorials/search/2a- advanced algorithms on PaRoutes.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This is the first part of a 2 part tutorial which runs the PaRoutes benchmark.\n",
     "In this half of the tutorial, we run search algorithms using a pre-trained reaction model.\n",
-    "Because these algorithms require policies and value functions,\n",
+    "Because these algorithms require policies and search heuristics,\n",
     "these must be carefully chosen before running the algorithm.\n",
     "\n",
     "**NOTE:** the PaRoutes reaction model requires the following additional packages:\n",
@@ -17,7 +17,7 @@
     "- `rdchiral` (to apply reaction templates)\n",
     "- `keras` (their pre-trained model is a template-classification model using keras)\n",
     "\n",
-    "The model also requires some data files, which can be downloaded with `paroutes_setup.sh`.",
+    "The model also requires some data files, which can be downloaded with `paroutes_setup.sh`.\n",
     "Running the following commands should set up everything:\n",
     "\n",
     "```\n",
@@ -344,7 +344,7 @@
     "\n",
     "1. A function to give the cost of each molecule (OrNode)\n",
     "2. A function to give the cost of each reaction (AndNode)\n",
-    "3. A function to estimate the minimum cost of leaf OrNodes (called the \"reaction number\" in the paper). This is effectively a value function in RL (except lower values are better)\n",
+    "3. A function to estimate the minimum cost of leaf OrNodes (called the \"reaction number\" in the paper). This functions as a search heuristic.\n",
     "\n",
     "We will implement these using subclasses of `BaseNodeEvaluator` class from `syntheseus.search.node_evaluation`."
    ]
@@ -406,13 +406,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#3: value function\n",
-    "# Here we just use a constant value function which is always 0,\n",
+    "#3: search heuristic\n",
+    "# Here we just use a constant 0 function,\n",
     "# corresponding to the \"retro*-0\" algorithm (the most optimistic)\n",
     "\n",
     "from syntheseus.search.node_evaluation.common import ConstantNodeEvaluator\n",
     "\n",
-    "retro_star_value_function = ConstantNodeEvaluator(0.0)"
+    "retro_star_search_heuristic = ConstantNodeEvaluator(0.0)"
    ]
   },
   {
@@ -428,7 +428,7 @@
     "    mol_inventory=inventory,\n",
     "    or_node_cost_fn=or_node_cost_fn,\n",
     "    and_node_cost_fn=and_node_cost_fn,\n",
-    "    value_function=retro_star_value_function,\n",
+    "    search_heuristic=retro_star_search_heuristic,\n",
     "    limit_reaction_model_calls=RXN_MODEL_CALL_LIMIT,\n",
     "    time_limit_s=TIME_LIMIT_S,\n",
     ")"
@@ -447,7 +447,7 @@
     "MCTS requires 2 input functions, with an optional third.\n",
     "\n",
     "1. A _reward function_ which defines the rewards for terminal states\n",
-    "2. A _value function_ which estimates the rewards attainable from a state\n",
+    "2. A _value function_ (search heuristic) which estimates the rewards attainable from a state\n",
     "3. (optional) a policy which assigns higher numbers to desirable actions\n",
     "\n",
     "We will implement these using subclasses of `BaseNodeEvaluator` class from `syntheseus.search.node_evaluation`."
@@ -490,7 +490,7 @@
     "# for demonstration purposes we just use a constant value function of 0.5\n",
     "# (this number is chosen to be between the lowest and highest rewards of 0/1\n",
     "\n",
-    "mcts_value_function = ConstantNodeEvaluator(0.5)"
+    "mcts_search_heuristic = ConstantNodeEvaluator(0.5)"
    ]
   },
   {
@@ -539,7 +539,7 @@
     "    reaction_model=rxn_model,\n",
     "    mol_inventory=inventory,\n",
     "    reward_function=mcts_reward_function,\n",
-    "    value_function=mcts_value_function,\n",
+    "    search_heuristic=mcts_search_heuristic,\n",
     "    policy=mcts_policy,\n",
     "    limit_reaction_model_calls=RXN_MODEL_CALL_LIMIT,\n",
     "    bound_constant=100.0,\n",


### PR DESCRIPTION
Retro*, MCTS, and proof number search all use some kind of function to estimate the "potential" of leaf nodes in the search graph and choose which node to expand at each iteration. In syntheseus we called this the "value function". However, in hindsight I think this is a poor name because:

1. Value function has a very specific meaning in reinforcement learning: it is the expected reward obtained from following a policy and *none* of the uses in syntheseus fit that. At best they are *estimates* of the value function.
2. From the RL setting, value function has the connotation of "higher is better", but for algorithms like retro* lower values are better. This is probably confusing to users.

To improve clarity, this PR renames value function to "search heuristic" whenever referring to a "general" value function rather than something which is specifically a value function (e.g. in MCTS). I think the term "search heuristic" is both more accurate and less confusing than value function, and at least to me the term implies that it will be interpreted differently for different algorithms.