### PR TITLE
Simplify class hierarchy for reaction objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
 - Improve efficiency and logging of retro* algorithm ([#62](https://github.com/microsoft/syntheseus/pull/62)) ([@austint])
-- Merge reaction and reaction model base classes in `search` and `reaction_predction` ([#63](https://github.com/microsoft/syntheseus/pull/63), [#67](https://github.com/microsoft/syntheseus/pull/67), [#73](https://github.com/microsoft/syntheseus/pull/73)) ([@austint])
+- Merge reaction and reaction model base classes in `search` and `reaction_predction` ([#63](https://github.com/microsoft/syntheseus/pull/63), [#67](https://github.com/microsoft/syntheseus/pull/67), [#73](https://github.com/microsoft/syntheseus/pull/73), [#74](https://github.com/microsoft/syntheseus/pull/74)) ([@austint])
 - Make reaction models return `Sequence[Reaction]` instead of `PredictionList` objects ([#61](https://github.com/microsoft/syntheseus/pull/61)) ([@austint])
 
 ### Added

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -35,7 +35,7 @@ from syntheseus.interface.models import (
     ReactionType,
 )
 from syntheseus.interface.molecule import Molecule
-from syntheseus.interface.reaction import MultiProductReaction, Reaction, SingleProductReaction
+from syntheseus.interface.reaction import Reaction, SingleProductReaction
 from syntheseus.reaction_prediction.data.dataset import (
     DataFold,
     DiskReactionDataset,
@@ -226,7 +226,7 @@ def compute_metrics(
     print(f"Testing model {model.__class__.__name__} with args {eval_args}")
 
     all_predictions: List[Sequence[Reaction]] = []
-    all_back_translation_predictions: List[List[Sequence[MultiProductReaction]]] = []
+    all_back_translation_predictions: List[List[Sequence[Reaction]]] = []
 
     model_timing_results: List[ModelTimingResults] = []
     back_translation_timing_results: List[ModelTimingResults] = []
@@ -261,7 +261,7 @@ def compute_metrics(
             output: Reaction
             if model.is_forward():
                 inputs.append(sample.reactants)
-                output = MultiProductReaction(reactants=sample.reactants, products=sample.products)
+                output = Reaction(reactants=sample.reactants, products=sample.products)
             else:
                 [single_product] = sample.products
                 assert isinstance(
@@ -286,7 +286,7 @@ def compute_metrics(
 
         batch_predictions: List[Sequence[ReactionType]] = results_with_timing.results
 
-        batch_back_translation_predictions: List[List[Sequence[MultiProductReaction]]] = []
+        batch_back_translation_predictions: List[List[Sequence[Reaction]]] = []
         for input, output, reaction_list in zip(inputs, outputs, batch_predictions):
             num_predictions.append(len(reaction_list))
 

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -261,7 +261,7 @@ def compute_metrics(
             output: Reaction
             if model.is_forward():
                 inputs.append(sample.reactants)
-                output = MultiProductReaction(reactants=sample.reactants, product=sample.products)
+                output = MultiProductReaction(reactants=sample.reactants, products=sample.products)
             else:
                 [single_product] = sample.products
                 assert isinstance(
@@ -323,7 +323,7 @@ def compute_metrics(
                 # Back translation is successful if any of the `back_translation_num_results` bags
                 # of products returned by the forward model contains the input.
                 back_translation_matches = [
-                    any(input in rxn.product for rxn in result)
+                    any(input in rxn.products for rxn in result)
                     for result in back_translation_results
                 ]
 

--- a/syntheseus/interface/models.py
+++ b/syntheseus/interface/models.py
@@ -6,7 +6,7 @@ from typing import Any, Generic, Optional, Sequence, TypeVar
 
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.molecule import Molecule
-from syntheseus.interface.reaction import MultiProductReaction, Reaction, SingleProductReaction
+from syntheseus.interface.reaction import Reaction, SingleProductReaction
 
 InputType = TypeVar("InputType")
 ReactionType = TypeVar("ReactionType", bound=Reaction)
@@ -175,6 +175,6 @@ class BackwardReactionModel(ReactionModel[Molecule, SingleProductReaction]):
         return False
 
 
-class ForwardReactionModel(ReactionModel[Bag[Molecule], MultiProductReaction]):
+class ForwardReactionModel(ReactionModel[Bag[Molecule], Reaction]):
     def is_forward(self) -> bool:
         return True

--- a/syntheseus/interface/reaction.py
+++ b/syntheseus/interface/reaction.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Collection, Optional, TypeVar
+from typing import Collection, Optional
 
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule
 from syntheseus.interface.typed_dict import TypedDict
-
-ReactantsType = TypeVar("ReactantsType")
 
 REACTION_SEPARATOR = ">"
 

--- a/syntheseus/interface/reaction.py
+++ b/syntheseus/interface/reaction.py
@@ -9,7 +9,6 @@ from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule
 from syntheseus.interface.typed_dict import TypedDict
 
 ReactantsType = TypeVar("ReactantsType")
-ProductType = TypeVar("ProductType")
 
 REACTION_SEPARATOR = ">"
 

--- a/syntheseus/interface/reaction.py
+++ b/syntheseus/interface/reaction.py
@@ -30,12 +30,11 @@ class ReactionMetaData(TypedDict, total=False):
 
 
 @dataclass(frozen=True, order=False)
-class Reaction(Generic[ReactantsType, ProductType]):
+class Reaction(Generic[ReactantsType]):
     """General reaction class."""
 
     # The molecule that the prediction is for and the predicted output:
     reactants: ReactantsType = field(hash=True, compare=True)
-    product: ProductType = field(hash=True, compare=True)
     identifier: Optional[str] = field(default=None, hash=True, compare=True)
 
     # Dictionary to hold additional metadata.
@@ -72,12 +71,22 @@ def reaction_string(reactants_str: str, product_str: str) -> str:
 
 
 @dataclass(frozen=True, order=False)
-class MultiProductReaction(Reaction[Bag[Molecule], Bag[Molecule]]):
+class _MultiProductBase:
+    """Dummy class to avoid non-default argument following default argument"""
+
+    products: Bag[Molecule] = field(hash=True, compare=True)
+
+
+@dataclass(frozen=True, order=False)
+class MultiProductReaction(
+    Reaction[Bag[Molecule]],
+    _MultiProductBase,
+):
     @property
     def reaction_smiles(self) -> str:
         return reaction_string(
             reactants_str=combine_mols_to_string(self.reactants),
-            product_str=combine_mols_to_string(self.product),
+            product_str=combine_mols_to_string(self.products),
         )
 
     @property
@@ -86,11 +95,18 @@ class MultiProductReaction(Reaction[Bag[Molecule], Bag[Molecule]]):
 
     @property
     def unique_products(self) -> set[Molecule]:
-        return set(self.product)
+        return set(self.products)
 
 
 @dataclass(frozen=True, order=False)
-class SingleProductReaction(Reaction[Bag[Molecule], Molecule]):
+class _SingleProductBase:
+    """Dummy class to avoid non-default argument following default argument"""
+
+    product: Molecule = field(hash=True, compare=True)
+
+
+@dataclass(frozen=True, order=False)
+class SingleProductReaction(Reaction[Bag[Molecule]], _SingleProductBase):
     @property
     def reaction_smiles(self) -> str:
         return reaction_string(

--- a/syntheseus/reaction_prediction/utils/inference.py
+++ b/syntheseus/reaction_prediction/utils/inference.py
@@ -65,7 +65,7 @@ def process_raw_smiles_outputs_forwards(
         if products is not None:
             predictions.append(
                 MultiProductReaction(
-                    product=products, reactants=input, metadata=cast(ReactionMetaData, metadata)
+                    products=products, reactants=input, metadata=cast(ReactionMetaData, metadata)
                 )
             )
 

--- a/syntheseus/reaction_prediction/utils/inference.py
+++ b/syntheseus/reaction_prediction/utils/inference.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Sequence, Union, cast
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.molecule import Molecule
 from syntheseus.interface.reaction import (
-    MultiProductReaction,
+    Reaction,
     ReactionMetaData,
     SingleProductReaction,
 )
@@ -43,8 +43,8 @@ def process_raw_smiles_outputs_backwards(
 
 def process_raw_smiles_outputs_forwards(
     input: Bag[Molecule], output_list: List[str], metadata_list: List[Dict[str, Any]]
-) -> Sequence[MultiProductReaction]:
-    """Convert raw SMILES outputs into a list of `MultiProductReaction` objects.
+) -> Sequence[Reaction]:
+    """Convert raw SMILES outputs into a list of `Reaction` objects.
     Like method `process_raw_smiles_outputs_backwards`, but for forward models.
 
     Args:
@@ -53,10 +53,10 @@ def process_raw_smiles_outputs_forwards(
         metadata_list: Additional metadata to attach to the predictions (e.g. probability).
 
     Returns:
-        A list of `MultiProductReactions`s; may be shorter than `outputs` if some of the raw
+        A list of `Reaction`s; may be shorter than `outputs` if some of the raw
         SMILES could not be parsed into valid reactant bags.
     """
-    predictions: List[MultiProductReaction] = []
+    predictions: List[Reaction] = []
 
     for raw_output, metadata in zip(output_list, metadata_list):
         products = molecule_bag_from_smiles(raw_output)
@@ -64,7 +64,7 @@ def process_raw_smiles_outputs_forwards(
         # Only consider the prediction if the SMILES can be parsed.
         if products is not None:
             predictions.append(
-                MultiProductReaction(
+                Reaction(
                     products=products, reactants=input, metadata=cast(ReactionMetaData, metadata)
                 )
             )

--- a/syntheseus/tests/interface/test_reaction.py
+++ b/syntheseus/tests/interface/test_reaction.py
@@ -26,7 +26,7 @@ def test_reaction_objects_basic():
     # Multi-product reaction
     rxn2 = MultiProductReaction(
         reactants=Bag([C5]),
-        product=Bag([C2, C3]),
+        products=Bag([C2, C3]),
     )
     assert rxn2.reaction_smiles == "CCCCC>>CC.CCC"
 

--- a/syntheseus/tests/interface/test_reaction.py
+++ b/syntheseus/tests/interface/test_reaction.py
@@ -7,7 +7,7 @@ import pytest
 
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.molecule import Molecule
-from syntheseus.interface.reaction import MultiProductReaction, SingleProductReaction
+from syntheseus.interface.reaction import Reaction, SingleProductReaction
 
 
 def test_reaction_objects_basic():
@@ -23,8 +23,8 @@ def test_reaction_objects_basic():
     )
     assert rxn1.reaction_smiles == "CC.CCC>>CCCCC"
 
-    # Multi-product reaction
-    rxn2 = MultiProductReaction(
+    # Standadr (multi-product) reaction
+    rxn2 = Reaction(
         reactants=Bag([C5]),
         products=Bag([C2, C3]),
     )


### PR DESCRIPTION
In #63 the new reaction class used the attribute "product" (no 's') to refer to both the single product in `SingleProductReaction` and the set of products in `MultiProductReaction`s. This is a bit confusing, so this PR refactors the class structure so that `MultiProductReaction` is simply called `Reaction`, and `SingleProductReaction` is a subclass which a `product` property. The resulting class structure contains no generics and is much simpler.