### PR TITLE
Improve test coverage and error handling in single-step evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
-- Improve efficiency and logging of retro* algorithm ([#62](https://github.com/microsoft/syntheseus/pull/62)) ([@austint])
 - Merge reaction and reaction model base classes in `search` and `reaction_predction` ([#63](https://github.com/microsoft/syntheseus/pull/63), [#67](https://github.com/microsoft/syntheseus/pull/67), [#73](https://github.com/microsoft/syntheseus/pull/73), [#74](https://github.com/microsoft/syntheseus/pull/74)) ([@austint])
 - Make reaction models return `Sequence[Reaction]` instead of `PredictionList` objects ([#61](https://github.com/microsoft/syntheseus/pull/61)) ([@austint])
+- Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
+- Improve efficiency and logging of retro* algorithm ([#62](https://github.com/microsoft/syntheseus/pull/62)) ([@austint])
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Make reaction models return `Sequence[Reaction]` instead of `PredictionList` objects ([#61](https://github.com/microsoft/syntheseus/pull/61)) ([@austint])
 - Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
 - Improve efficiency and logging of retro* algorithm ([#62](https://github.com/microsoft/syntheseus/pull/62)) ([@austint])
+- Improve error handling in single-step evaluation and allow CLI to use the default checkpoints ([#75](https://github.com/microsoft/syntheseus/pull/75)) ([@kmaziarz])
 
 ### Added
 

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -405,7 +405,11 @@ def print_and_save(results: EvalResults, config: EvalConfig, suffix: str = "") -
         if f.name not in ("model_info", "top_k", "predictions", "back_translation_predictions"):
             print(f"{f.name}: {getattr(results, f.name)}")
 
-    print(" ".join(["top_k results", suffix]) + ":")
+    if suffix:
+        print(f"top_k results {suffix}:")
+    else:
+        print("top_k results:")
+
     for k, result in chosen_topk_results.items():
         print(f"{k}: {result}", flush=True)
 

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -270,10 +270,10 @@ def compute_metrics(
                 inputs.append(sample.reactants)
                 output = Reaction(reactants=sample.reactants, products=sample.products)
             else:
-                [single_product] = sample.products
-                assert isinstance(
-                    single_product, Molecule
+                assert (
+                    len(sample.products) == 1
                 ), f"Model expected a single target product, got {len(sample.products)}"
+                [single_product] = sample.products
 
                 inputs.append(cast(InputType, single_product))
                 output = SingleProductReaction(reactants=sample.reactants, product=single_product)

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -404,7 +404,7 @@ def print_and_save(results: EvalResults, config: EvalConfig, suffix: str = "") -
         if f.name not in ("model_info", "top_k", "predictions", "back_translation_predictions"):
             print(f"{f.name}: {getattr(results, f.name)}")
 
-    print(f"top_k results {suffix}:")
+    print(" ".join(["top_k results", suffix]) + ":")
     for k, result in chosen_topk_results.items():
         print(f"{k}: {result}", flush=True)
 

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field, fields
 from functools import partial
 from itertools import islice
 from statistics import mean, median
-from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Sequence, cast
+from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Sequence, Tuple, cast
 
 from more_itertools import batched
 from omegaconf import MISSING, OmegaConf
@@ -249,7 +249,7 @@ def compute_metrics(
         total=math.ceil(test_dataset_size / batch_size),
     ):
         # Tell mypy what the type of `batch` is as `batched` seems to lose it.
-        batch = cast(tuple[ReactionSample], batch)
+        batch = cast(Tuple[ReactionSample], batch)
 
         inputs: List[InputType] = []
         outputs: List[ReactionType] = []

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -34,7 +34,6 @@ from syntheseus.interface.models import (
     ReactionModel,
     ReactionType,
 )
-from syntheseus.interface.molecule import Molecule
 from syntheseus.interface.reaction import Reaction, SingleProductReaction
 from syntheseus.reaction_prediction.data.dataset import (
     DataFold,
@@ -49,6 +48,8 @@ from syntheseus.reaction_prediction.inference.config import (
 )
 from syntheseus.reaction_prediction.utils.config import (
     get_config as cli_get_config,
+)
+from syntheseus.reaction_prediction.utils.config import (
     get_error_message_for_missing_value,
 )
 from syntheseus.reaction_prediction.utils.metrics import (
@@ -436,7 +437,7 @@ def run_from_config(
     print(config)
 
     if OmegaConf.is_missing(config, "data_dir"):
-        raise ValueError(f"data_dir should be set to a directory containing a reaction dataset")
+        raise ValueError("data_dir should be set to a directory containing a reaction dataset")
 
     if OmegaConf.is_missing(config, "model_class"):
         raise ValueError(

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -42,8 +42,15 @@ from syntheseus.reaction_prediction.data.dataset import (
     ReactionDataset,
 )
 from syntheseus.reaction_prediction.data.reaction_sample import ReactionSample
-from syntheseus.reaction_prediction.inference.config import BackwardModelConfig, ForwardModelConfig
-from syntheseus.reaction_prediction.utils.config import get_config as cli_get_config
+from syntheseus.reaction_prediction.inference.config import (
+    BackwardModelClass,
+    BackwardModelConfig,
+    ForwardModelConfig,
+)
+from syntheseus.reaction_prediction.utils.config import (
+    get_config as cli_get_config,
+    get_error_message_for_missing_value,
+)
 from syntheseus.reaction_prediction.utils.metrics import (
     ModelTimingResults,
     TopKMetricsAccumulator,
@@ -427,6 +434,14 @@ def run_from_config(
 
     print("Running eval with the following config:")
     print(config)
+
+    if OmegaConf.is_missing(config, "data_dir"):
+        raise ValueError(f"data_dir should be set to a directory containing a reaction dataset")
+
+    if OmegaConf.is_missing(config, "model_class"):
+        raise ValueError(
+            get_error_message_for_missing_value("model_class", [c.name for c in BackwardModelClass])
+        )
 
     get_model_fn = partial(get_model, batch_size=config.batch_size, num_gpus=config.num_gpus)
     model = get_model_fn(config, remove_duplicates=config.skip_repeats)

--- a/syntheseus/reaction_prediction/utils/config.py
+++ b/syntheseus/reaction_prediction/utils/config.py
@@ -55,3 +55,7 @@ def get_config(
     config = OmegaConf.merge(schema, *conf_yamls, conf_cli)
     OmegaConf.set_readonly(config, True)  # should not be written to
     return cast(R, config)
+
+
+def get_error_message_for_missing_value(name: str, possible_values: List[str]) -> str:
+    return f"{name} should be set to one of [{', '.join(possible_values)}]"

--- a/syntheseus/reaction_prediction/utils/model_loading.py
+++ b/syntheseus/reaction_prediction/utils/model_loading.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Union
 
+from omegaconf import OmegaConf
+
 from syntheseus.interface.models import ReactionModel
 from syntheseus.reaction_prediction.inference.config import BackwardModelConfig, ForwardModelConfig
 
@@ -20,7 +22,10 @@ def get_model(
 
     def model_fn(device):
         return config.model_class.value(
-            model_dir=config.model_dir, device=device, **config.model_kwargs, **model_kwargs
+            model_dir=OmegaConf.select(config, "model_dir"),
+            device=device,
+            **config.model_kwargs,
+            **model_kwargs,
         )
 
     if num_gpus == 0:

--- a/syntheseus/tests/reaction_prediction/cli/test_eval.py
+++ b/syntheseus/tests/reaction_prediction/cli/test_eval.py
@@ -155,7 +155,7 @@ def test_print_and_save(tmp_path: Path) -> None:
 
     config = EvalConfig(
         data_dir=str(tmp_path),
-        model_class=BackwardModelClass.RetroKNN,
+        model_class=BackwardModelClass.RetroKNN,  # Model choice is arbitrary here.
         results_dir=str(tmp_path),
     )
 

--- a/syntheseus/tests/reaction_prediction/cli/test_eval.py
+++ b/syntheseus/tests/reaction_prediction/cli/test_eval.py
@@ -1,4 +1,3 @@
-import tempfile
 from itertools import cycle, islice
 from typing import Iterable, List, Sequence
 
@@ -77,8 +76,7 @@ def test_get_results(repeat: bool, measure_time: bool) -> None:
         # ...otherwise we get fewer.
         assert results_with_repeats == DummyModel.RESULTS
 
-
-def test_print_and_save():
+def test_print_and_save(tmp_path: Path) -> None:
     input_mol = Molecule("c1ccccc1N")
     output_mol_bag = Bag([Molecule("c1ccccc1"), Molecule("N")])
 
@@ -98,11 +96,10 @@ def test_print_and_save():
         predictions=[[SingleProductReaction(product=input_mol, reactants=output_mol_bag)]],
     )
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        config = EvalConfig(
-            data_dir=temp_dir,
-            model_class=BackwardModelClass.RetroKNN,
-            results_dir=temp_dir,
-        )
+    config = EvalConfig(
+        data_dir=tmp_path,
+        model_class=BackwardModelClass.RetroKNN,
+        results_dir=tmp_path,
+    )
 
-        print_and_save(results, config)
+    print_and_save(results, config)

--- a/syntheseus/tests/reaction_prediction/cli/test_eval.py
+++ b/syntheseus/tests/reaction_prediction/cli/test_eval.py
@@ -103,6 +103,12 @@ def test_get_results(repeat: bool, measure_time: bool) -> None:
 def test_compute_metrics(
     forward: bool, num_dataset_truncation: int, num_top_results: int, tmp_path: Path
 ) -> None:
+    """Test the `compute_metrics` function.
+
+    By extension this also tests `get_results` (and thus calls the model). As `compute_metrics` has
+    a slightly different behaviour depending on whether the model is forward or backward, this test
+    checks both cases.
+    """
     samples = []
     for input, output in [("C.N", "CN"), ("NC=O", "CN"), ("C.C", "CC")]:
         if forward:


### PR DESCRIPTION
Recently we had some breaking changes to `eval_single_step.py` merged to `main` due to insufficient test coverage. This PR extends the coverage by adding tests for `compute_metrics` (using both a forward and a backward reaction model). It also improves error handling in the evaluation script (errors otherwise produced by `OmegaConf` tend to be a bit cryptic) and allows `get_model` to make use of default model weights (otherwise this feature was not accessible when running through one of the the CLI entrypoints).