### PR TITLE
Further reduce code duplication between reaction classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Merge reaction and reaction model base classes in `search` and `reaction_predction` ([#63](https://github.com/microsoft/syntheseus/pull/63), [#67](https://github.com/microsoft/syntheseus/pull/67), [#73](https://github.com/microsoft/syntheseus/pull/73), [#74](https://github.com/microsoft/syntheseus/pull/74)) ([@austint])
+- Merge reaction and reaction model base classes in `search` and `reaction_predction` ([#63](https://github.com/microsoft/syntheseus/pull/63), [#67](https://github.com/microsoft/syntheseus/pull/67), [#73](https://github.com/microsoft/syntheseus/pull/73), [#74](https://github.com/microsoft/syntheseus/pull/74), [#76](https://github.com/microsoft/syntheseus/pull/76)) ([@austint], [@kmaziarz])
 - Make reaction models return `Sequence[Reaction]` instead of `PredictionList` objects ([#61](https://github.com/microsoft/syntheseus/pull/61)) ([@austint])
 - Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
 - Improve efficiency and logging of retro* algorithm ([#62](https://github.com/microsoft/syntheseus/pull/62)) ([@austint])

--- a/syntheseus/interface/molecule.py
+++ b/syntheseus/interface/molecule.py
@@ -85,4 +85,9 @@ class Molecule:
 
 
 def molecule_bag_to_smiles(mols: Bag[Molecule]) -> str:
+    """Combine SMILES strings of molecules in a `Bag` into a single string.
+
+    For two bags that represent the same multiset of molecules this function will return the same
+    result, because iteration order over a `Bag` is deterministic (sorted using default comparator).
+    """
     return SMILES_SEPARATOR.join(mol.smiles for mol in mols)

--- a/syntheseus/interface/molecule.py
+++ b/syntheseus/interface/molecule.py
@@ -7,6 +7,7 @@ from typing import Optional, Union
 
 from rdkit import Chem
 
+from syntheseus.interface.bag import Bag
 from syntheseus.interface.typed_dict import TypedDict
 
 SMILES_SEPARATOR = "."
@@ -81,3 +82,7 @@ class Molecule:
         if "rdkit_mol" not in self.metadata:
             self.metadata["rdkit_mol"] = Chem.MolFromSmiles(self.smiles)
         return self.metadata["rdkit_mol"]
+
+
+def molecule_bag_to_smiles(mols: Bag[Molecule]) -> str:
+    return SMILES_SEPARATOR.join(mol.smiles for mol in mols)

--- a/syntheseus/interface/reaction.py
+++ b/syntheseus/interface/reaction.py
@@ -52,18 +52,16 @@ class Reaction:
         return set(self.products)
 
     @property
-    def reactants_combined(self) -> str:
+    def reactants_str(self) -> str:
         return molecule_bag_to_smiles(self.reactants)
 
     @property
-    def products_combined(self) -> str:
+    def products_str(self) -> str:
         return molecule_bag_to_smiles(self.products)
 
     @property
     def reaction_smiles(self) -> str:
-        return reaction_string(
-            reactants_str=self.reactants_combined, products_str=self.products_combined
-        )
+        return reaction_string(reactants_str=self.reactants_str, products_str=self.products_str)
 
     def __str__(self) -> str:
         output = self.reaction_smiles

--- a/syntheseus/interface/reaction.py
+++ b/syntheseus/interface/reaction.py
@@ -25,9 +25,9 @@ class ReactionMetaData(TypedDict, total=False):
     ground_truth_match: bool  # whether this reaction matches ground truth
 
 
-def reaction_string(reactants_str: str, product_str: str) -> str:
+def reaction_string(reactants_str: str, products_str: str) -> str:
     """Produces a consistent string representation of a reaction."""
-    return f"{reactants_str}{2*REACTION_SEPARATOR}{product_str}"
+    return f"{reactants_str}{2 * REACTION_SEPARATOR}{products_str}"
 
 
 @dataclass(frozen=True, order=False)
@@ -52,10 +52,17 @@ class Reaction:
         return set(self.products)
 
     @property
+    def reactants_combined(self) -> str:
+        return molecule_bag_to_smiles(self.reactants)
+
+    @property
+    def products_combined(self) -> str:
+        return molecule_bag_to_smiles(self.products)
+
+    @property
     def reaction_smiles(self) -> str:
         return reaction_string(
-            reactants_str=molecule_bag_to_smiles(self.reactants),
-            product_str=molecule_bag_to_smiles(self.products),
+            reactants_str=self.reactants_combined, products_str=self.products_combined
         )
 
     def __str__(self) -> str:

--- a/syntheseus/interface/reaction.py
+++ b/syntheseus/interface/reaction.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Collection, Optional
+from typing import Optional
 
 from syntheseus.interface.bag import Bag
-from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule
+from syntheseus.interface.molecule import Molecule, molecule_bag_to_smiles
 from syntheseus.interface.typed_dict import TypedDict
 
 REACTION_SEPARATOR = ">"
@@ -23,11 +23,6 @@ class ReactionMetaData(TypedDict, total=False):
     reaction_id: int  # template id or other kind of reaction id, if applicable
     reaction_smiles: str  # reaction smiles for this reaction
     ground_truth_match: bool  # whether this reaction matches ground truth
-
-
-def combine_mols_to_string(mols: Collection[Molecule]) -> str:
-    """Produces a consistent string representation of a collection of molecules."""
-    return SMILES_SEPARATOR.join([mol.smiles for mol in sorted(mols)])
 
 
 def reaction_string(reactants_str: str, product_str: str) -> str:
@@ -59,8 +54,8 @@ class Reaction:
     @property
     def reaction_smiles(self) -> str:
         return reaction_string(
-            reactants_str=combine_mols_to_string(self.reactants),
-            product_str=combine_mols_to_string(self.products),
+            reactants_str=molecule_bag_to_smiles(self.reactants),
+            product_str=molecule_bag_to_smiles(self.products),
         )
 
     def __str__(self) -> str:

--- a/syntheseus/reaction_prediction/chem/utils.py
+++ b/syntheseus/reaction_prediction/chem/utils.py
@@ -39,7 +39,3 @@ def molecule_bag_from_smiles(smiles: str) -> Optional[Bag[Molecule]]:
     except ValueError:
         # If any of the components ends up invalid we return `None` instead.
         return None
-
-
-def molecule_bag_to_smiles(mols: Bag[Molecule]) -> str:
-    return SMILES_SEPARATOR.join(mol.smiles for mol in mols)

--- a/syntheseus/reaction_prediction/data/reaction_sample.py
+++ b/syntheseus/reaction_prediction/data/reaction_sample.py
@@ -23,9 +23,9 @@ class ReactionSample(Reaction):
     @property
     def reaction_smiles_with_reagents(self) -> str:
         return (
-            f"{self.reactants_combined}{REACTION_SEPARATOR}"
+            f"{self.reactants_str}{REACTION_SEPARATOR}"
             f"{self.reagents}{REACTION_SEPARATOR}"
-            f"{self.products_combined}"
+            f"{self.products_str}"
         )
 
     @classmethod

--- a/syntheseus/reaction_prediction/data/reaction_sample.py
+++ b/syntheseus/reaction_prediction/data/reaction_sample.py
@@ -19,7 +19,6 @@ class ReactionSample(Reaction):
 
     reagents: str = field(default="", hash=True, compare=True)
     mapped_reaction_smiles: Optional[str] = field(default=None, hash=False, compare=False)
-    template: Optional[str] = field(default=None, hash=False, compare=False)
 
     @property
     def reaction_smiles_with_reagents(self) -> str:

--- a/syntheseus/reaction_prediction/data/reaction_sample.py
+++ b/syntheseus/reaction_prediction/data/reaction_sample.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Type, TypeVar
 
 from syntheseus.interface.bag import Bag
-from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule, molecule_bag_to_smiles
-from syntheseus.interface.reaction import REACTION_SEPARATOR
+from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule
+from syntheseus.interface.reaction import REACTION_SEPARATOR, Reaction
 from syntheseus.reaction_prediction.chem.utils import remove_atom_mapping
 from syntheseus.reaction_prediction.utils.misc import undictify_bag_of_molecules
 
@@ -14,39 +14,12 @@ ReactionType = TypeVar("ReactionType", bound="ReactionSample")
 
 
 @dataclass(frozen=True, order=False)
-class ReactionSample:
-    """
-    Wraps around a reaction.
+class ReactionSample(Reaction):
+    """Extends a `Reaction` with fields and methods relevant to data loading and saving."""
 
-    It is frozen since it should not need to be edited,
-    and this will auto-implement __eq__ and __hash__ methods.
-    """
-
-    reactants: Bag[Molecule] = field(hash=True, compare=True)
-    products: Bag[Molecule] = field(hash=True, compare=True)
     reagents: str = field(default="", hash=True, compare=True)
-    identifier: Optional[str] = field(default=None, hash=True, compare=True)
-
     mapped_reaction_smiles: Optional[str] = field(default=None, hash=False, compare=False)
     template: Optional[str] = field(default=None, hash=False, compare=False)
-
-    metadata: Dict[str, Any] = field(
-        default_factory=lambda: dict(),
-        hash=False,
-        compare=False,
-    )
-
-    @property
-    def reactants_combined(self) -> str:
-        return molecule_bag_to_smiles(self.reactants)
-
-    @property
-    def products_combined(self) -> str:
-        return molecule_bag_to_smiles(self.products)
-
-    @property
-    def reaction_smiles(self) -> str:
-        return f"{self.reactants_combined}{2 * REACTION_SEPARATOR}{self.products_combined}"
 
     @property
     def reaction_smiles_with_reagents(self) -> str:

--- a/syntheseus/reaction_prediction/data/reaction_sample.py
+++ b/syntheseus/reaction_prediction/data/reaction_sample.py
@@ -5,12 +5,9 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Type, TypeVar
 
 from syntheseus.interface.bag import Bag
-from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule
+from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule, molecule_bag_to_smiles
 from syntheseus.interface.reaction import REACTION_SEPARATOR
-from syntheseus.reaction_prediction.chem.utils import (
-    molecule_bag_to_smiles,
-    remove_atom_mapping,
-)
+from syntheseus.reaction_prediction.chem.utils import remove_atom_mapping
 from syntheseus.reaction_prediction.utils.misc import undictify_bag_of_molecules
 
 ReactionType = TypeVar("ReactionType", bound="ReactionSample")


### PR DESCRIPTION
Our data loading code produces `ReactionSample` objects, which (as of #74) are very similar to `Reaction`s, except for holding a few extra things. These two classes also duplicate some of the functionality, e.g. utils for stringifying a `Bag` of `Molecule`s. This PR makes an initial attempt at deduplicating these two classes, making `ReactionSample` inherit from `Reaction`.

Longer term we could potentially combine the two classes entirely (we can defer this to a future PR to speed up the release of `v0.4.0`).