### PR TITLE
Enable docs versioning

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Configure Git Credentials
+      - name: Configure Git
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git fetch origin gh-pages --depth=1
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -27,5 +28,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material mkdocs-jupyter
-      - run: mkdocs gh-deploy --force
+      - run: pip install mkdocs-material mkdocs-jupyter mike
+      - run: mike deploy --push --update-aliases dev

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Syntheseus
+site_url: https://microsoft.github.io/syntheseus/
 
 repo_name: microsoft/syntheseus
 repo_url: https://github.com/microsoft/syntheseus
@@ -46,3 +47,8 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
+
+extra:
+  version:
+    default: stable
+    provider: mike


### PR DESCRIPTION
So far our documentation was not versioned, meaning that the website always served the version that was most recently built. However, we generally recommend installing the latest `pip`-released version, which led to a pitfall in which we release new features or backward-compatible changes to `main` but delay updating the docs because that would make them out-of-sync with the state of the library as available via `pip`.

This PR resolves this issue by enabling docs versioning using `mike`. Now the docs are still built regularly (automatically on each merge to `main`, but this can also be triggered manually) but these builds overwrite a special version called `dev`, which is supposed to correspond to the state of `main`. On top of this, there are versions of the docs corresponding to `pip`-released versions of the package, which are released manually and shouldn't be overwritten. This is done via
```
mike deploy --push --update-aliases x.y.z stable
```
The above releases `x.y.z` and also reset the version alias `stable`; this should be set to the latest `pip`-released version.

Both the CI pipeline as well as local calls to `mike` generate new commits on the `gh-pages` branch. Currently, two versions are released:
- `dev`, which was released by triggering the CI pipeline
- `0.3.0`, which I released manually from an older[^1] version of the code matching the `v0.3.0` release

Now going to [microsoft.github.io/syntheseus/](https://microsoft.github.io/syntheseus/) redirects to the `stable` version (which equals `0.3.0`), but allows choosing `dev` which is the current state of `main`. One difference between the versions is that the latter mentions the Graph2Edits model, which was integrated _after_ the release of `v0.3.0` (and so it wouldn't be available to users installing from `pip`).

[^1]: Normally I would have used the commit corresponding to the release of `v0.3.0`, but shortly after that commit we pushed a few more PRs that improved the docs significantly (in particular by adding the tutorials), and these PRs contained no breaking changes or new features that would make the docs out-of-sync with `v0.3.0`. Hence, the commit I used to release this version of the docs includes these few extra documentation-related PRs that were merged after the release.