### PR TITLE
Update docs and tutorials

### DIFF
--- a/docs/cli/eval_single_step.md
+++ b/docs/cli/eval_single_step.md
@@ -2,16 +2,15 @@
 
 ## Usage
 
-To run single-step model evaluation, run
-
 ```
 syntheseus eval-single-step \
     data_dir=[DATA_DIR] \
+    fold=[TRAIN, VAL or TEST] \
     model_class=[MODEL_CLASS] \
     model_dir=[MODEL_DIR]
 ```
 
-The script accepts further arguments to customize the evaluation such as which data fold to use; see `BaseEvalConfig` for the complete list.
+The `eval-single-step` command accepts further arguments to customize the evaluation; see `BaseEvalConfig` in `cli/eval_single_step.py` for the complete list.
 
 The code will scan `data_dir` looking for files matching `*{train, val, test}.{jsonl, csv, smi}` and select the right data format based on the file extension. An error will be raised in case of ambiguity. Only the fold that was selected for evaluation has to be present.
 

--- a/docs/cli/search.md
+++ b/docs/cli/search.md
@@ -16,7 +16,7 @@ Both the search targets and the purchasable molecules inventory are expected to 
 The `search` command accepts further arguments to configure the search algorithm; see `SearchConfig` in `cli/search.py` for the complete list.
 
 !!! info
-    When using one of the natively supported single-step models you can omit `model_dir`, which will cause `syntheseus` to use a default checkpoint trained on USPTO-50K (see [here](../../single_step) for details).
+    When using one of the natively supported single-step models you can omit `model_dir`, which will cause `syntheseus` to use a default checkpoint trained on USPTO-50K (see [here](../single_step.md) for details).
 
 ## Configuring the search algorithm
 

--- a/docs/cli/search.md
+++ b/docs/cli/search.md
@@ -1,0 +1,27 @@
+# Running Search
+
+## Usage
+
+```
+syntheseus search \
+    search_targets_file=[SMILES_FILE_WITH_SEARCH_TARGETS] \
+    inventory_smiles_file=[SMILES_FILE_WITH_PURCHASABLE_MOLECULES] \
+    model_class=[MODEL_CLASS] \
+    model_dir=[MODEL_DIR] \
+    time_limit_s=[NUMBER_OF_SECONDS_PER_TARGET]
+```
+
+Both the search targets and the purchasable molecules inventory are expected to be plain SMILES files, with one molecule per line.
+
+The `search` command accepts further arguments to configure the search algorithm; see `SearchConfig` in `cli/search.py` for the complete list.
+
+!!! info
+    When using one of the natively supported single-step models you can omit `model_dir`, which will cause `syntheseus` to use a default checkpoint trained on USPTO-50K (see [here](../../single_step) for details).
+
+## Configuring the search algorithm
+
+You can set the search algorithm explicitly using the `search_algorithm` argument to `retro_star` (default), `mcts` or `pdvn`.
+For all of those algorithms you can vary hyperparameters such as the policy/value functions or MCTS bound type/constant.
+
+In practice however there may be no need to override any hyperparameters, especially if combining Retro\* or MCTS with one of the natively supported models, as for those `syntheseus` will automatically choose sensible hyperparameter defaults (listed in `cli/search_config.yml`).
+[In our experience](https://arxiv.org/abs/2310.19796) both Retro* and MCTS show similar performance when tuned properly, but you may want to try both for your particular usecase and see which one works best empirically.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,7 +48,7 @@ There are also two installation sources:
 !!! note
 
     Make sure you are viewing the version of the docs matching your `syntheseus` installation.
-    Select the `x.y.z` version you installed (go [here](https://microsoft.github.io/syntheseus/stable/) for the latest one) if you used `pip`,
+    Select the `x.y.z` version you installed if you used `pip` (go [here](https://microsoft.github.io/syntheseus/stable/) for the latest one),
     or [dev](https://microsoft.github.io/syntheseus/dev/) if you installed `syntheseus` directly from GitHub.
 
 Core installation includes only minimal dependencies (no ML libraries), while full installation includes all supported models and also dependencies for visualization/development.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,9 +47,9 @@ There are also two installation sources:
 
 !!! note
 
-    Make sure you are viewing the version of the docs that matches your `syntheseus` installation.
-    Select [stable](https://microsoft.github.io/syntheseus/stable/) (0.3.0) if using the latest version available via `pip`,
-    and [dev](https://microsoft.github.io/syntheseus/dev/) if installing directly from GitHub.
+    Make sure you are viewing the version of the docs matching your `syntheseus` installation.
+    Select the `x.y.z` version you installed (go [here](https://microsoft.github.io/syntheseus/stable/) for the latest one) if you used `pip`,
+    or [dev](https://microsoft.github.io/syntheseus/dev/) if you installed `syntheseus` directly from GitHub.
 
 Core installation includes only minimal dependencies (no ML libraries), while full installation includes all supported models and also dependencies for visualization/development.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,6 +45,12 @@ There are also two installation sources:
     pip install -e ".[all]"
     ```
 
+!!! note
+
+    Make sure you are viewing the version of the docs that matches your `syntheseus` installation.
+    Select [stable](https://microsoft.github.io/syntheseus/stable/) (0.3.0) if using the latest version available via `pip`,
+    and [dev](https://microsoft.github.io/syntheseus/dev/) if installing directly from GitHub.
+
 Core installation includes only minimal dependencies (no ML libraries), while full installation includes all supported models and also dependencies for visualization/development.
 
 Instructions above assume you already cloned the repository via

--- a/docs/tutorials/quick_start.ipynb
+++ b/docs/tutorials/quick_start.ipynb
@@ -69,9 +69,7 @@
      "text": [
       "1: Cc1ccc(B(O)O)cc1 + Cc1ccc(Br)cc1\n",
       "2: Cc1ccc(B(O)O)cc1 + Cc1ccc(I)cc1\n",
-      "3: Cc1ccc(B(O)O)cc1 + Cc1ccc(Br)cc1\n",
-      "4: Cc1ccc(B(O)O)cc1 + Cc1ccc(I)cc1\n",
-      "5: Cc1ccc(Br)cc1 + Cc1ccc([Mg+])cc1\n"
+      "3: Cc1ccc(Br)cc1 + Cc1ccc([Mg+])cc1\n"
      ]
     }
    ],
@@ -81,7 +79,7 @@
     "\n",
     "def print_results(results) -> None:\n",
     "    for idx, prediction in enumerate(results):\n",
-    "        print(f\"{idx + 1}: \" + mols_to_str(prediction.output))\n",
+    "        print(f\"{idx + 1}: \" + mols_to_str(prediction.reactants))\n",
     "\n",
     "[results] = model([test_mol], num_results=5)\n",
     "print_results(results)"
@@ -91,49 +89,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The outputs from the underlying model contain duplicates. We can use a higher-level utility function to get unique outputs as well as timing."
+    "We only got 3 results (despite requesting 5) as `syntheseus` automatically deduplicates the model outputs.\n",
+    "\n",
+    "As all single-step models are set up in a consistent way, it's easy to run several models and compare their outputs."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1: Cc1ccc(B(O)O)cc1 + Cc1ccc(Br)cc1\n",
-      "2: Cc1ccc(B(O)O)cc1 + Cc1ccc(I)cc1\n",
-      "3: Cc1ccc(Br)cc1 + Cc1ccc([Mg+])cc1\n",
-      "\n",
-      "Time taken by model call: 0.04s\n"
-     ]
-    }
-   ],
-   "source": [
-    "from syntheseus.cli.eval_single_step import get_results\n",
-    "\n",
-    "results_with_timing = get_results(\n",
-    "    model, inputs=[test_mol], num_results=5, measure_time=True\n",
-    ")\n",
-    "\n",
-    "print_results(results_with_timing.results[0])\n",
-    "\n",
-    "time_taken = results_with_timing.model_timing_results.time_model_call\n",
-    "print(f\"\\nTime taken by model call: {time_taken:.2f}s\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As `syntheseus` sets up all single-step models in a consistent way, it's easy to run several models and compare their outputs."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -167,9 +130,9 @@
     "    # When interested in very few predictions (e.g. one), it may be\n",
     "    # useful to set `num_results > 1`, as this will cause e.g.\n",
     "    # larger beam size for models based on beam search.\n",
-    "    [results] = get_results(model, [test_mol], num_results=5).results\n",
+    "    [results] = model([test_mol], num_results=5)\n",
     "\n",
-    "    top_prediction = results[0].output\n",
+    "    top_prediction = results[0].reactants\n",
     "    print(f\"{model.name + ':':12} {mols_to_str(top_prediction)}\")"
    ]
   },
@@ -187,29 +150,12 @@
     "To run multi-step search we need three things:\n",
     "- a reaction model\n",
     "- an inventory of purchasable (building block) molecules\n",
-    "- a search algorithm\n",
-    "\n",
-    "We can use any of the single-step models shown above, but they need to be wrapped to make them usable in search."
+    "- a search algorithm"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from syntheseus.reaction_prediction.utils.syntheseus_wrapper import (\n",
-    "    SyntheseusBackwardReactionModel,\n",
-    ")\n",
-    "\n",
-    "search_model = SyntheseusBackwardReactionModel(\n",
-    "    model=LocalRetroModel(), num_results=10\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,13 +164,18 @@
     "    AndOr_BreadthFirstSearch\n",
     ")\n",
     "\n",
+    "# Set up a reaction model with caching enabled. Number of reactions\n",
+    "# to request from the model at each step of the search needs to be\n",
+    "# provided at construction time.\n",
+    "model = LocalRetroModel(use_cache=True, default_num_results=10)\n",
+    "\n",
     "# Dummy inventory with just two purchasable molecules.\n",
     "inventory = SmilesListInventory(\n",
     "    smiles_list=[\"Cc1ccc(B(O)O)cc1\", \"O=Cc1ccc(I)cc1\"]\n",
     ")\n",
     "\n",
     "search_algorithm = AndOr_BreadthFirstSearch(\n",
-    "    reaction_model=search_model,\n",
+    "    reaction_model=model,\n",
     "    mol_inventory=inventory,\n",
     "    limit_iterations=100,  # max number of algorithm iterations\n",
     "    limit_reaction_model_calls=100,  # max number of model calls\n",
@@ -234,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -267,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -302,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
   - Single-Step Models: single_step.md
 - CLI:
   - Single-Step Evaluation: cli/eval_single_step.md
+  - Running Search: cli/search.md
 - Tutorials:
   - Quick Start: tutorials/quick_start.ipynb
 


### PR DESCRIPTION
This PR combines a few updates to our docs and tutorials:
- updating the "Quick Start" tutorial after recent refactoring
- explaining in the installation section that the version of the docs used should match how `syntheseus` was installed
- adding basic documentation for the `search` CLI endpoint

Docs that include the changes from this PR are already up under [microsoft.github.io/syntheseus/dev/](https://microsoft.github.io/syntheseus/dev/).