### PR TITLE
Add tutorial for integrating custom models and improve README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,3 @@ MANIFEST
 # Unit test / coverage reports
 .coverage
 .coverage.*
-
-# Cloned single-step model repositories
-syntheseus/reaction_prediction/environments/external/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Added
 
 - Integrate the Graph2Edits model ([#65](https://github.com/microsoft/syntheseus/pull/65), [#66](https://github.com/microsoft/syntheseus/pull/66)) ([@kmaziarz])
-- Add a new tutorial employing non-toy single-step models ([#54](https://github.com/microsoft/syntheseus/pull/54)) ([@kmaziarz])
+- Improve the docs and add tutorials ([#54](https://github.com/microsoft/syntheseus/pull/54), [#77](https://github.com/microsoft/syntheseus/pull/77), [#78](https://github.com/microsoft/syntheseus/pull/78), [#79](https://github.com/microsoft/syntheseus/pull/79)) ([@kmaziarz])
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 <div align="center">
     <img src="https://github.com/microsoft/syntheseus/assets/61470923/f01a9939-61fa-4461-a124-c13eddcdd75a" height="50px">
     <h3><i>Navigating the labyrinth of synthesis planning</i></h3>
-</div>
 
 ---
+
+<p align="center">
+  <a href="https://microsoft.github.io/syntheseus/stable">Docs</a> •
+  <a href="https://microsoft.github.io/syntheseus/stable/cli/eval_single_step/">CLI</a> •
+  <a href="https://microsoft.github.io/syntheseus/stable/tutorials/quick_start/">Tutorials</a> •
+  <a href="https://arxiv.org/abs/2310.19796">Paper</a>
+</p>
 
 [![CI](https://github.com/microsoft/syntheseus/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/microsoft/syntheseus/actions/workflows/ci.yml)
 [![Python Version](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/)
@@ -11,14 +17,16 @@
 [![code style](https://img.shields.io/badge/code%20style-black-202020.svg)](https://github.com/ambv/black)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/microsoft/syntheseus/blob/main/LICENSE)
 
+</div>
+
+## Overview
+
 Syntheseus is a package for end-to-end retrosynthetic planning.
 - ⚒️ Combines search algorithms and reaction models in a standardized way
 - 🧭 Includes implementations of common search algorithms
 - 🧪 Includes wrappers for state-of-the-art reaction models
 - ⚙️ Exposes a simple API to plug in custom models and algorithms
 - 📈 Can be used to benchmark components of a retrosynthesis pipeline
-
-To learn about `syntheseus`'s features and API visit [microsoft.github.io/syntheseus](https://microsoft.github.io/syntheseus).
 
 ## Quick Start
 
@@ -31,7 +39,7 @@ conda activate syntheseus-full
 pip install "syntheseus[all]"
 ```
 
-See [documentation](https://microsoft.github.io/syntheseus/installation) if you prefer a more lightweight installation that only includes the parts you actually need.
+See [here](https://microsoft.github.io/syntheseus/installation) if you prefer a more lightweight installation that only includes the parts you actually need.
 
 ## Development
 

--- a/docs/tutorials/custom_model.ipynb
+++ b/docs/tutorials/custom_model.ipynb
@@ -1,0 +1,383 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Implementing the model wrapper"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To integrate a custom model we need to wrap it into the shared model interface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from syntheseus.interface.models import BackwardReactionModel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a demonstration we'll integrate a dummy model which only accepts molecules that are chains of carbon atoms `CC...C` and predicts \"reactions\" that split that chain into two parts. The _only_ method we need to implement is `_get_reactions`; we split it into a few helper methods below for readability."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Sequence\n",
+    "from syntheseus.interface.bag import Bag\n",
+    "from syntheseus.interface.molecule import Molecule\n",
+    "from syntheseus.interface.reaction import SingleProductReaction\n",
+    "\n",
+    "\n",
+    "class ToyModel(BackwardReactionModel):\n",
+    "    def _get_reactions(\n",
+    "        self, inputs: list[Molecule], num_results: int\n",
+    "    ) -> list[Sequence[SingleProductReaction]]:\n",
+    "        return [\n",
+    "            self._get_reactions_single(mol)[:num_results]\n",
+    "            for mol in inputs\n",
+    "        ]\n",
+    "\n",
+    "    def _get_reaction_score(self, i: int, n_atoms: int) -> float:\n",
+    "        # Give higher score to reactions which break the input into\n",
+    "        # equal-sized pieces.\n",
+    "        return float(min(i, n_atoms - i))\n",
+    "\n",
+    "    def _get_reactions_single(\n",
+    "        self, mol: Molecule\n",
+    "    ) -> Sequence[SingleProductReaction]:\n",
+    "        n = len(mol.smiles)\n",
+    "        if mol.smiles != n * \"C\":\n",
+    "            return []\n",
+    "\n",
+    "        scores = [self._get_reaction_score(i, n) for i in range(1, n)]\n",
+    "        score_total = sum(scores)\n",
+    "\n",
+    "        probs = [score / score_total for score in scores]\n",
+    "\n",
+    "        reactions = []\n",
+    "        for i, prob in zip(range(1, n), probs):\n",
+    "            reactant_1 = Molecule(i * \"C\")\n",
+    "            reactant_2 = Molecule((n - i) * \"C\")\n",
+    "\n",
+    "            reactions.append(\n",
+    "                SingleProductReaction(\n",
+    "                    reactants=Bag([reactant_1, reactant_2]),\n",
+    "                    product=mol,\n",
+    "                    metadata={\"probability\": prob},\n",
+    "                )\n",
+    "            )\n",
+    "    \n",
+    "        return sorted(\n",
+    "            reactions,\n",
+    "            key=lambda r: r.metadata[\"probability\"],\n",
+    "            reverse=True,\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's make sure this works. Note that we implement `_get_reactions` but call the models using `__call__`; this allows `syntheseus` to inject extra processing such as deduplication or caching."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = ToyModel()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CC.CC>>CCCC (probability: 0.500)\n",
+      "C.CCC>>CCCC (probability: 0.250)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def print_predictions(model, smiles: str):\n",
+    "    [reactions] = model([Molecule(smiles)])\n",
+    "\n",
+    "    for reaction in reactions:\n",
+    "        probability = reaction.metadata[\"probability\"]\n",
+    "        print(f\"{reaction} (probability: {probability:.3f})\")\n",
+    "\n",
+    "print_predictions(model, \"CCCC\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The model is working as expected. `CCC.C>>CCCC` is not returned, as order of reactants in a `Bag` doesn't matter, and thus it's the same as `C.CCC>>CCCC`. However, note that currently `syntheseus` only removes duplicated reactions but does _not_ add the probabilities of all duplicates together (and search algorithms generally do not depend on all the probabilities summing up to 1). If you prefer to instead sum the probabilities of duplicate reactions, you can implement this behaviour yourself by overriding `filter_reactions` (or even in `_get_reactions` directly)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running search"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As in the \"Quick Start\" tutorial, we will now proceed to running multi-step search using our newly integrated model. This time we will use a proper search algorithm (Retro*) instead of BFS, so that it takes into account the single-step probabilities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from syntheseus.search.analysis.route_extraction import (\n",
+    "    iter_routes_time_order,\n",
+    ")\n",
+    "\n",
+    "from syntheseus.search.mol_inventory import SmilesListInventory\n",
+    "from syntheseus.search.algorithms.best_first.retro_star import (\n",
+    "    RetroStarSearch\n",
+    ")\n",
+    "from syntheseus.search.node_evaluation.common import (\n",
+    "    ConstantNodeEvaluator,\n",
+    "    ReactionModelLogProbCost,\n",
+    ")\n",
+    "\n",
+    "def get_routes(model):\n",
+    "    search_algorithm = RetroStarSearch(\n",
+    "        reaction_model=model,\n",
+    "        mol_inventory=SmilesListInventory(smiles_list=[\"C\"]),\n",
+    "        limit_iterations=100,  # max number of algorithm iterations\n",
+    "        limit_reaction_model_calls=100,  # max number of model calls\n",
+    "        time_limit_s=60.0,  # max runtime in seconds\n",
+    "        value_function=ConstantNodeEvaluator(0.0),\n",
+    "        and_node_cost_fn=ReactionModelLogProbCost(),\n",
+    "    )\n",
+    "\n",
+    "    output_graph, _ = search_algorithm.run_from_mol(\n",
+    "        Molecule(\"CCCCCCCC\")\n",
+    "    )\n",
+    "    routes = list(\n",
+    "        iter_routes_time_order(output_graph, max_routes=100)\n",
+    "    )\n",
+    "\n",
+    "    print(f\"Found {len(routes)} routes\")\n",
+    "    return output_graph, routes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 22 routes\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = ToyModel(use_cache=True)\n",
+    "output_graph, routes = get_routes(model)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see how many times the reaction model was actually called."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.num_calls()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This makes sense: even though there are many more nodes in the search graph, the search only enountered 7 unique non-purchasable products (chains with lengths between 2 and 8); as we set `use_cache=True` the model was called on each of these products exactly once. We can pass `count_cache=True` to get the number of calls _including_ those for which the answer was already cached."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.num_calls(count_cache=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a look at the routes that were found. To make sure they were explored starting with higher probability steps, we plot the first and last route found."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from syntheseus.search.visualization import visualize_andor\n",
+    "\n",
+    "for name, idx in [(\"first\", 0), (\"last\", -1)]:\n",
+    "    visualize_andor(\n",
+    "        output_graph, filename=f\"route_{name}.pdf\", nodes=routes[idx]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The contents of the files `route_{first, last}.pdf` should look like the below. Search only considers _unique_ reactants for a given reaction step; even though our model always returns two reactants, if these are the same then search will create a reaction with only a single child node. Given that our probabilities were set up to prefer splitting the input into equal-sized chunks, the first route found halves the input SMILES in each reaction step, while the last route always splits out a single atom.\n",
+    "\n",
+    "<img align=\"top\" src=\"https://github.com/microsoft/syntheseus/assets/61470923/d755250e-0973-45c2-9d32-479426f71a05\" width=\"142px\">\n",
+    "<img align=\"top\" src=\"https://github.com/microsoft/syntheseus/assets/61470923/6a2cae70-d527-428c-a3c9-d5b0ab13db0b\" width=\"500px\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the case above search had an easy job finding the best route as the higher probability steps also led to reaching building block molecules sooner. In general, algorithms will be implicitly biased towards not only higher probability steps but also taking less steps overall. However, we can modify our toy model to strongly prefer unbalanced splits, and verify that then the order of routes is roughly reversed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C.CCCCCCC>>CCCCCCCC (probability: 0.464)\n",
+      "CC.CCCCCC>>CCCCCCCC (probability: 0.029)\n",
+      "CCC.CCCCC>>CCCCCCCC (probability: 0.006)\n",
+      "CCCC.CCCC>>CCCCCCCC (probability: 0.002)\n"
+     ]
+    }
+   ],
+   "source": [
+    "class ToyModelUnbalanced(ToyModel):\n",
+    "    def _get_reaction_score(self, i: int, n_atoms: int) -> float:\n",
+    "        score = super()._get_reaction_score(i, n_atoms)\n",
+    "        return (1.0 / score) ** 4.0\n",
+    "\n",
+    "print_predictions(ToyModelUnbalanced(), \"CCCCCCCC\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 22 routes\n"
+     ]
+    }
+   ],
+   "source": [
+    "output_graph, routes = get_routes(\n",
+    "    ToyModelUnbalanced(use_cache=True)\n",
+    ")\n",
+    "\n",
+    "visualize_andor(\n",
+    "    output_graph,\n",
+    "    filename=f\"route_first_unbalanced.pdf\",\n",
+    "    nodes=routes[0],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Indeed, the first route found during this search is the \"maximally unbalanced\" one, which was the last route found previously."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "syntheseus-single-step",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Running Search: cli/search.md
 - Tutorials:
   - Quick Start: tutorials/quick_start.ipynb
+  - Integrating a Custom Model: tutorials/custom_model.ipynb
 
 plugins:
   - mkdocs-jupyter


### PR DESCRIPTION
This PR adds a new tutorial that shows how to integrate a custom reaction model and run search with it (for demonstration purposes it uses a toy model which is a simplified version of a model we use in tests). Additionally, it also slightly improves the README by adding links at the top to docs, CLI reference, tutorials and our paper. The first three technically all link to somewhere in the docs, but having them spelled out at the top may make it more clear to users that these things (especially tutorials) do exist. Finally, I also apply a small cleanup to `.gitignore` to remove an entry which is no longer relevant.