### PR TITLE
Make basic classes from `interface` importable from top-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - Suppress the remaining noisy logs and warnings coming from single-step models ([#53](https://github.com/microsoft/syntheseus/pull/53)) ([@kmaziarz])
 - Improve efficiency and logging of retro* algorithm ([#62](https://github.com/microsoft/syntheseus/pull/62)) ([@austint])
 - Improve error handling in single-step evaluation and allow CLI to use the default checkpoints ([#75](https://github.com/microsoft/syntheseus/pull/75)) ([@kmaziarz])
+- Make basic classes from `interface` importable from top-level ([#81](https://github.com/microsoft/syntheseus/pull/81)) ([@austint])
 
 ### Added
 

--- a/docs/tutorials/custom_model.ipynb
+++ b/docs/tutorials/custom_model.ipynb
@@ -359,7 +359,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "syntheseus-single-step",
    "language": "python",
    "name": "python3"
   },
@@ -377,5 +377,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/docs/tutorials/custom_model.ipynb
+++ b/docs/tutorials/custom_model.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from syntheseus.interface.models import BackwardReactionModel"
+    "from syntheseus import BackwardReactionModel"
    ]
   },
   {
@@ -37,9 +37,7 @@
    "outputs": [],
    "source": [
     "from typing import Sequence\n",
-    "from syntheseus.interface.bag import Bag\n",
-    "from syntheseus.interface.molecule import Molecule\n",
-    "from syntheseus.interface.reaction import SingleProductReaction\n",
+    "from syntheseus import Bag, Molecule, SingleProductReaction\n",
     "\n",
     "\n",
     "class ToyModel(BackwardReactionModel):\n",
@@ -361,7 +359,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "syntheseus-single-step",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -379,5 +377,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/tutorials/quick_start.ipynb
+++ b/docs/tutorials/quick_start.ipynb
@@ -278,7 +278,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "syntheseus-single-step",
    "language": "python",
    "name": "python3"
   },
@@ -296,5 +296,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/docs/tutorials/quick_start.ipynb
+++ b/docs/tutorials/quick_start.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from syntheseus.interface.molecule import Molecule\n",
+    "from syntheseus import Molecule\n",
     "from syntheseus.reaction_prediction.inference import LocalRetroModel\n",
     "\n",
     "test_mol = Molecule(\"Cc1ccc(-c2ccc(C)cc2)cc1\")\n",
@@ -278,7 +278,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "syntheseus-single-step",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -296,5 +296,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/syntheseus/__init__.py
+++ b/syntheseus/__init__.py
@@ -1,0 +1,14 @@
+from syntheseus.interface.bag import Bag
+from syntheseus.interface.models import BackwardReactionModel, ForwardReactionModel, ReactionModel
+from syntheseus.interface.molecule import Molecule
+from syntheseus.interface.reaction import Reaction, SingleProductReaction
+
+__all__ = [
+    "Molecule",
+    "Reaction",
+    "SingleProductReaction",
+    "Bag",
+    "ReactionModel",
+    "BackwardReactionModel",
+    "ForwardReactionModel",
+]


### PR DESCRIPTION
Almost any script using syntheseus in a non-trivial way will need to import a handful of essential classes from `syntheseus.interface`. This PR makes them importable from top-level, allowing users to write

```python
from syntheseus import Molecule, Reaction, Bag
```

instead of

```python
from syntheseus.interface.molecule import Molecule
from syntheseus.interface.reaction import Reaction
from syntheseus.interface.bag import Bag
```

Honestly I often forget where to import these things from, and if I find this annoying, I imagine syntheseus's users would feel similarly.