### PR TITLE
Add a workflow to release a new stable version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,11 @@ name: Docs
 on:
   push:
     branches: [ main ]
+  workflow_call:
+    inputs:
+      versions:
+        required: true
+        type: string
   workflow_dispatch:
 
 permissions:
@@ -29,4 +34,4 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install mkdocs-material mkdocs-jupyter mike
-      - run: mike deploy --push --update-aliases dev
+      - run: mike deploy --push --update-aliases ${{ inputs.versions != '' && inputs.versions || 'dev' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release Stable Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  push-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - run: git tag -a ${{ inputs.version }} -m "Release ${{ inputs.version }}"
+      - run: git push origin ${{ inputs.version }}
+  build-docs:
+    uses: ./.github/workflows/docs.yml
+    with:
+      versions: ${{ inputs.version }} stable


### PR DESCRIPTION
This PR adds a new GitHub Action that partially automates the process of releasing a new stable version of `syntheseus`. It tags the latest commit with an appropriate version tag and builds the docs (using a generalized version of the docs building pipeline).

I could not fully test the new action yet since it does not exist on `main`, but in case any issues arise when releasing v0.4.0 the action will be updated in a follow-up PR.