### PR TITLE
Fix the version release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,16 @@ jobs:
   push-tag:
     runs-on: ubuntu-latest
     steps:
-      - run: git tag -a ${{ inputs.version }} -m "Release ${{ inputs.version }}"
-      - run: git push origin ${{ inputs.version }}
+      - uses: actions/checkout@v4
+      - name: Configure Git
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - run: |
+          git tag -a v${{ inputs.version }} -m "Release v${{ inputs.version }}"
+          git push origin v${{ inputs.version }}
   build-docs:
+    needs: push-tag
     uses: ./.github/workflows/docs.yml
     with:
       versions: ${{ inputs.version }} stable


### PR DESCRIPTION
The version release workflow added in #87 had a few issues, which are all fixed in this PR:
- the step to create the git tag did not check out the repository, nor did it configure the git credentials properly
- the same version string was used for both tagging and building the docs, while we currently use the `vX.Y.Z` format for the tag and `X.Y.Z` for the docs version
- the doc building step did not specify a dependency on the tagging step, which meant it would run and publish the docs even if tagging was not successful