### PR TITLE
Fix incorrectly uploaded RetroKNN weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix incorrectly uploaded RetroKNN weights ([#91](https://github.com/microsoft/syntheseus/pull/91)) ([@kmaziarz])
+
 ## [0.4.0] - 2024-04-10
 
 ### Changed

--- a/docs/single_step.md
+++ b/docs/single_step.md
@@ -13,7 +13,7 @@ See table below for the links to the default checkpoints.
 | [LocalRetro](https://figshare.com/ndownloader/files/42287319)  | trained by us |
 | [MEGAN](https://figshare.com/ndownloader/files/42012732)       | trained by us |
 | [MHNreact](https://figshare.com/ndownloader/files/42012777)    | trained by us |
-| [RetroKNN](https://figshare.com/ndownloader/files/43636584)    | trained by us |
+| [RetroKNN](https://figshare.com/ndownloader/files/45662430)    | trained by us |
 | [RootAligned](https://figshare.com/ndownloader/files/42012792) | released by authors |
 
 ??? note "More advanced datasets"

--- a/syntheseus/reaction_prediction/inference/default_checkpoint_links.yml
+++ b/syntheseus/reaction_prediction/inference/default_checkpoint_links.yml
@@ -5,7 +5,7 @@ backward:
   LocalRetro: https://figshare.com/ndownloader/files/42287319
   MEGAN: https://figshare.com/ndownloader/files/42012732
   MHNreact: https://figshare.com/ndownloader/files/42012777
-  RetroKNN: https://figshare.com/ndownloader/files/43636584
+  RetroKNN: https://figshare.com/ndownloader/files/45662430
   RootAligned: https://figshare.com/ndownloader/files/42012792
 forward:
   Chemformer: https://figshare.com/ndownloader/files/42012708


### PR DESCRIPTION
As noticed by @panpiort8, the default USPTO50K-trained RetroKNN weights did not reproduce the USPTO50K accuracy reported in our paper, only getting to ~50% instead of ~55%. It turns out that the weights got mixed up when uploading from our internal storage to figshare. In short, the RetroKNN weights consist of LocalRetro weights and an activation store for retrieval, but the store present in the checkpoint was generated using a _different_ checkpoint of LocalRetro than the one it was uploaded with. After fixing this, the accuracy is back to its expected ~55% range.