### PR TITLE
Fix issues with GLN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix incorrectly uploaded RetroKNN weights ([#91](https://github.com/microsoft/syntheseus/pull/91)) ([@kmaziarz])
+- Fix GLN weights and issues in its model wrapper ([#92](https://github.com/microsoft/syntheseus/pull/92)) ([@kmaziarz])
 
 ## [0.4.0] - 2024-04-10
 

--- a/docs/single_step.md
+++ b/docs/single_step.md
@@ -8,7 +8,7 @@ See table below for the links to the default checkpoints.
 | Model checkpoint link                                          | Source |
 |----------------------------------------------------------------|--------|
 | [Chemformer](https://figshare.com/ndownloader/files/42009888)  | finetuned by us starting from checkpoint released by authors |
-| [GLN](https://figshare.com/ndownloader/files/42012720)         | released by authors |
+| [GLN](https://figshare.com/ndownloader/files/45882867)         | released by authors |
 | [Graph2Edits](https://figshare.com/ndownloader/files/44194301) | released by authors |
 | [LocalRetro](https://figshare.com/ndownloader/files/42287319)  | trained by us |
 | [MEGAN](https://figshare.com/ndownloader/files/42012732)       | trained by us |

--- a/syntheseus/reaction_prediction/inference/default_checkpoint_links.yml
+++ b/syntheseus/reaction_prediction/inference/default_checkpoint_links.yml
@@ -1,6 +1,6 @@
 backward:
   Chemformer: https://figshare.com/ndownloader/files/42009888
-  GLN: https://figshare.com/ndownloader/files/42012720
+  GLN: https://figshare.com/ndownloader/files/45882867
   Graph2Edits: https://figshare.com/ndownloader/files/44194301
   LocalRetro: https://figshare.com/ndownloader/files/42287319
   MEGAN: https://figshare.com/ndownloader/files/42012732

--- a/syntheseus/reaction_prediction/inference/gln.py
+++ b/syntheseus/reaction_prediction/inference/gln.py
@@ -57,6 +57,10 @@ class GLNModel(ExternalBackwardReactionModel):
 
             self.model = RetroGLN(self.model_dir, chkpt_path)
 
+    @property
+    def name(self) -> str:
+        return "GLN"
+
     def get_parameters(self):
         return self.model.gln.parameters()
 
@@ -73,7 +77,9 @@ class GLNModel(ExternalBackwardReactionModel):
             return process_raw_smiles_outputs_backwards(
                 input=input,
                 output_list=result["reactants"],
-                metadata_list=[{"probability": probability} for probability in result["scores"]],
+                metadata_list=[
+                    {"probability": probability.item()} for probability in result["scores"]
+                ],
             )
 
     def _get_reactions(


### PR DESCRIPTION
The GLN model is the only model class that uses a bespoke environment based on Python 3.7 instead of the shared environment that uses Python 3.9. Due to this, it is not tested in CI, and is generally prone to bugs being introduced over time.

After trying to run the GLN model using the weights uploaded to figshare, I found that the upload was incomplete, and some files were missing from the checkpoint, preventing the model from being loaded. On top of this, there were a few small issues in the wrapper that accumulated over time, which also needed to be addressed to get the model to run again. This PR changes the weights link to a complete upload and also fixes the small issues in the model wrapper.