### PR TITLE
Shift the pandas dependency to the model packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Shift the `pandas` dependency to the external model packages ([#94](https://github.com/microsoft/syntheseus/pull/94)) ([@kmaziarz])
+
 ## [0.4.1] - 2024-05-04
 
 ### Fixed

--- a/environment_full.yml
+++ b/environment_full.yml
@@ -8,7 +8,6 @@ dependencies:
   - dgl-cuda11.3  # LocalRetro, RetroKNN
   - faiss-gpu     # RetroKNN
   - numpy
-  - pandas
   - pip
   - python==3.9.7
   - pytorch=1.10.2=py3.9_cuda11.3_cudnn8.2.0_0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
 ]
 chemformer = ["syntheseus-chemformer==0.1.1"]
 graph2edits = ["syntheseus-graph2edits==0.2.0"]
-local-retro = ["syntheseus-local-retro==0.4.0"]
+local-retro = ["syntheseus-local-retro==0.5.0"]
 megan = ["syntheseus-megan==0.1.0"]
 mhn-react = ["syntheseus-mhnreact==1.0.0"]
 retro-knn = ["syntheseus[local-retro]", "torch-scatter"]


### PR DESCRIPTION
The `pandas` dependency was so far part of our conda environment without any pin, but it seems more recent versions can cause some issues in LocalRetro when combined with `rdkit`, causing CI to fail. Given that `pandas` is available from PyPI, this PR removes the dependency from the environment and instead adds it (with a `<2.2` constraint) to the `syntheseus-local-retro` package.