### PR TITLE
Fix coverage report upload in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       with:
         name: .coverage.core-${{ matrix.python-version }}
         path: .coverage.*
+        include-hidden-files: true
   test-models:
     runs-on: ubuntu-latest
     defaults:
@@ -74,6 +75,7 @@ jobs:
       with:
         name: .coverage.models
         path: .coverage.*
+        include-hidden-files: true
   coverage:
     needs: [test-core, test-models]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Earlier this week, GitHub rolled out an [update to the `upload-artifact` action](https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/), which makes it ignore hidden files by default (this is to reduce the risk of accidentally including unwanted files e.g. credentials). As the `.coverage.*` files are hidden (i.e. their name starts with `.`), they started being skipped in the upload, and our CI started failing. This PR fixes things by setting the `include-hidden-files` flag to restore the previous behaviour.