### PR TITLE
Extend single-step evaluation with stereo-agnostic results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Reuse search results when given a partially filled directory ([#98](https://github.com/microsoft/syntheseus/pull/98)) ([@kmaziarz])
 - Expose `stop_on_first_solution` as a CLI flag ([#100](https://github.com/microsoft/syntheseus/pull/100)) ([@kmaziarz])
+- Extend single-step evaluation with stereo-agnostic results ([#102](https://github.com/microsoft/syntheseus/pull/102)) ([@kmaziarz])
 
 ### Fixed
 

--- a/syntheseus/reaction_prediction/chem/utils.py
+++ b/syntheseus/reaction_prediction/chem/utils.py
@@ -2,8 +2,8 @@ from typing import Optional
 
 from rdkit import Chem
 
-from syntheseus.interface.bag import Bag
-from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule
+from syntheseus import Bag, Molecule, Reaction
+from syntheseus.interface.molecule import SMILES_SEPARATOR
 
 ATOM_MAPPING_PROP_NAME = "molAtomMapNumber"
 
@@ -27,6 +27,19 @@ def remove_atom_mapping(smiles: str) -> str:
     remove_atom_mapping_from_mol(mol)
 
     return Chem.MolToSmiles(mol)
+
+
+def remove_stereo_information(mol: Molecule) -> Molecule:
+    return Molecule(Chem.MolToSmiles(mol.rdkit_mol, isomericSmiles=False))
+
+
+def remove_stereo_information_from_reaction(reaction: Reaction) -> Reaction:
+    return Reaction(
+        reactants=Bag([remove_stereo_information(mol) for mol in reaction.reactants]),
+        products=Bag([remove_stereo_information(mol) for mol in reaction.products]),
+        identifier=reaction.identifier,
+        metadata=reaction.metadata,
+    )
 
 
 def molecule_bag_from_smiles_strict(smiles: str) -> Bag[Molecule]:

--- a/syntheseus/tests/reaction_prediction/chem/test_utils.py
+++ b/syntheseus/tests/reaction_prediction/chem/test_utils.py
@@ -1,8 +1,10 @@
 from rdkit import Chem
 
+from syntheseus import Molecule
 from syntheseus.reaction_prediction.chem.utils import (
     remove_atom_mapping,
     remove_atom_mapping_from_mol,
+    remove_stereo_information,
 )
 
 
@@ -17,3 +19,11 @@ def test_remove_mapping() -> None:
     remove_atom_mapping_from_mol(mol)
 
     assert Chem.MolToSmiles(mol) == smiles_unmapped
+
+
+def test_remove_stereo_information() -> None:
+    mol = Molecule("CC(N)C#N")
+    mols_chiral = [Molecule("C[C@H](N)C#N"), Molecule("C[C@@H](N)C#N")]
+
+    assert len(set([mol] + mols_chiral)) == 3
+    assert len(set([mol] + [remove_stereo_information(m) for m in mols_chiral])) == 1

--- a/syntheseus/tests/reaction_prediction/chem/test_utils.py
+++ b/syntheseus/tests/reaction_prediction/chem/test_utils.py
@@ -1,10 +1,11 @@
 from rdkit import Chem
 
-from syntheseus import Molecule
+from syntheseus import Bag, Molecule, Reaction, SingleProductReaction
 from syntheseus.reaction_prediction.chem.utils import (
     remove_atom_mapping,
     remove_atom_mapping_from_mol,
     remove_stereo_information,
+    remove_stereo_information_from_reaction,
 )
 
 
@@ -27,3 +28,25 @@ def test_remove_stereo_information() -> None:
 
     assert len(set([mol] + mols_chiral)) == 3
     assert len(set([mol] + [remove_stereo_information(m) for m in mols_chiral])) == 1
+
+
+def test_remove_stereo_information_from_reaction() -> None:
+    reactants = Bag([Molecule("CCC"), Molecule("CC(N)C#N")])
+    reactants_chiral = Bag([Molecule("CCC"), Molecule("C[C@H](N)C#N")])
+
+    product = Molecule("CC(N)C#N")
+    product_chiral = Molecule("C[C@H](N)C#N")
+
+    rxn = Reaction(reactants=reactants, products=Bag([product]))
+    rxn_chiral = Reaction(reactants=reactants_chiral, products=Bag([product_chiral]))
+    rxn_stereo_removed = remove_stereo_information_from_reaction(rxn_chiral)
+
+    assert type(rxn_stereo_removed) is Reaction
+    assert rxn_stereo_removed == rxn
+
+    sp_rxn = SingleProductReaction(reactants=reactants, product=product)
+    sp_rxn_chiral = SingleProductReaction(reactants=reactants_chiral, product=product_chiral)
+    sp_rxn_stero_removed = remove_stereo_information_from_reaction(sp_rxn_chiral)
+
+    assert type(sp_rxn_stero_removed) is SingleProductReaction
+    assert sp_rxn_stero_removed == sp_rxn


### PR DESCRIPTION
This PR adds an `include_results_modulo_stereo` flag to the single-step evaluation script to additionally compute metrics (top-k accuracy, MRR) under a relaxed notion of success which ignores stereochemistry information. This can be useful to assess what fraction of errors made by the model are due to a mismatch in chirality. Additionally, this PR also slightly tidies up the printing of eval results.