### PR TITLE
Update GLN environment to Python 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update GLN to Python 3.9 ([#103](https://github.com/microsoft/syntheseus/pull/103)) ([@kmaziarz])
+
 ### Added
 
 - Reuse search results when given a partially filled directory ([#98](https://github.com/microsoft/syntheseus/pull/98)) ([@kmaziarz])

--- a/syntheseus/reaction_prediction/environment_gln/Dockerfile
+++ b/syntheseus/reaction_prediction/environment_gln/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azureml/openmpi3.1.2-cuda10.0-cudnn7-ubuntu18.04
+FROM mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04
 MAINTAINER krmaziar@microsoft.com
 
 # Set bash, as conda doesn't like dash
@@ -12,13 +12,17 @@ ENV PIP_NO_CACHE_DIR=1
 
 # Install the dependencies into conda's default environment
 COPY ./environment.yml /tmp/
-RUN conda install mamba -n base -c conda-forge
-RUN mamba env update -p /opt/miniconda -f /tmp/environment.yml && conda clean -ay
+RUN conda config --remove channels defaults && \
+    conda config --add channels conda-forge && \
+    conda update --all && \
+    conda install mamba -n base -c conda-forge && \
+    conda clean --all --yes
+RUN mamba env update -p /opt/miniconda -f /tmp/environment.yml && conda clean --all --yes
 
 # Install RDKit from source
 RUN git clone https://github.com/rdkit/rdkit.git
 WORKDIR /rdkit
-RUN git checkout 7ad9e0d161110f758350ca080be0fc05530bee1e
+RUN git checkout 8bd74d91118f3fdb370081ef0a18d71715e7c6cf
 RUN mkdir build && cd build && cmake -DPy_ENABLE_SHARED=1 \
     -DRDK_INSTALL_INTREE=ON \
     -DRDK_INSTALL_STATIC_LIBS=OFF \
@@ -28,10 +32,9 @@ RUN mkdir build && cd build && cmake -DPy_ENABLE_SHARED=1 \
     .. && make && make install
 WORKDIR /
 
-# Install GLN (this relies on `CUDA_HOME` being set correctly).
-RUN git clone https://github.com/Hanjun-Dai/GLN.git
+# Install GLN (this relies on `CUDA_HOME` being set correctly)
+RUN git clone https://github.com/kmaziarz/GLN.git
 WORKDIR /GLN
-RUN git checkout b5bd7b181a61a8289cc1d1a33825b2c417bed0ef
 RUN pip install -e .
 
 ENV PYTHONPATH=$PYTHONPATH:/rdkit:/GLN

--- a/syntheseus/reaction_prediction/environment_gln/environment.yml
+++ b/syntheseus/reaction_prediction/environment_gln/environment.yml
@@ -1,26 +1,23 @@
 name: gln-env
 channels:
-  - conda-forge
   - pytorch
+  - nvidia
+  - conda-forge
+  - defaults
+  - pyg
 dependencies:
-  - cudatoolkit=10.0
-  - cudatoolkit-dev=10
-  - python=3.7
-  - pytorch==1.2.0
+  - python=3.9
+  - pytorch=1.13.0=py3.9_cuda11.6_cudnn8.3.2_0
   - scipy
   - tqdm
-  # Dependencies below are needed to build `rdkit` from source:
   - boost
   - boost-cpp
   - cairo
   - cmake
   - eigen
   - gxx_linux-64
+  - mkl<2024.1.0
   - pillow
   - pkg-config
   - py-boost
-  - pip:
-    - torch-cluster==1.4.5
-    - torch-geometric==1.3.2
-    - torch-scatter==1.4.0
-    - torch-sparse==0.4.3
+  - pyg==2.1.0


### PR DESCRIPTION
Unlike all other supported single-step models, GLN uses a separate environment defined with `docker`, as it depends on building `rdkit` from source. GLN is also the only model using Python 3.7 - a version which reached its end-of-life last year. This PR keeps the `docker`-based setup, but updates the GLN code and environment to Python 3.9, so that in a future version of `syntheseus` we can raise the required Python version to 3.9 and get rid of backward compatibility hacks.