### PR TITLE
Add an option to set time limit for route extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Reuse search results when given a partially filled directory ([#98](https://github.com/microsoft/syntheseus/pull/98)) ([@kmaziarz])
 - Expose `stop_on_first_solution` as a CLI flag ([#100](https://github.com/microsoft/syntheseus/pull/100)) ([@kmaziarz])
+- Add an option to set time limit for route extraction ([#104](https://github.com/microsoft/syntheseus/pull/104)) ([@kmaziarz])
 - Extend single-step evaluation with stereo-agnostic results ([#102](https://github.com/microsoft/syntheseus/pull/102)) ([@kmaziarz])
 
 ### Fixed

--- a/syntheseus/search/analysis/route_extraction.py
+++ b/syntheseus/search/analysis/route_extraction.py
@@ -31,7 +31,7 @@ def _iter_top_routes(
     this is the case but are not sure in general.
 
     Args:
-        graph: graph to iterate over. Could be tree, but does not need to be.
+        graph: Graph to iterate over. Could be tree, but does not need to be.
         cost_fn: Gives the cost of a route (specified by the set of nodes).
             A cost of inf means the route will not be returned.
         cost_lower_bound: A lower bound of the cost. The lower bound means that
@@ -181,11 +181,11 @@ def iter_routes_cost_order(
     It is also assumed that `node.has_solution` is set beforehand.
 
     Args:
-        graph: graph whose routes to extract
-        max_routes: maximum number of routes to yield.
+        graph: Graph to extract routes from.
+        max_routes: Maximum number of routes to yield.
         max_time_s: Maximum total number of seconds to spend extracting routes.
-        stop_cost: if provided, iterator will terminate once a route of cost
-            >= stop_cost is encountered
+        stop_cost: If provided, iterator will terminate once a route of cost
+            larger than `stop_cost` is encountered.
     """
 
     for cost, route in _iter_top_routes(
@@ -232,8 +232,8 @@ def iter_routes_time_order(
     Creation time is measured by `node.creation_time`.
 
     Args:
-        graph: graph whose routes to extract
-        max_routes: maximum number of routes to yield.
+        graph: Graph to extract routes from.
+        max_routes: Maximum number of routes to yield.
         max_time_s: Maximum total number of seconds to spend extracting routes.
     """
 


### PR DESCRIPTION
Our route extraction utilities can behave very differently depending on the structure of the underlying graph, and thus it's hard to predict how long extracting a given number of routes will take. In some cases, even the time between yielding one route and the next can be quite substantial. To allow for more control over route extraction, this PR adds a `max_time_s` argument to those utilities, which can be used to cap the total time spent. This time constraint is enforced in every iteration (as opposed to on every route found), which allows for following the limit much more closely.