### PR TITLE
Correctly specify dependency on typing_extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "omegaconf",            # reaction_prediction
     "rdkit",                # reaction_prediction, search
     "tqdm",                 # reaction_prediction
+    "typing_extensions ; python_version < '3.8'",  # for TypedDict and Protocol imports
 ]
 
 [project.optional-dependencies]

--- a/syntheseus/interface/bag.py
+++ b/syntheseus/interface/bag.py
@@ -1,7 +1,13 @@
+import sys
 from collections.abc import Collection
 from typing import Generic, Iterable, Iterator, TypeVar
 
-from typing_extensions import Protocol
+# mypy-compatible import recommended here:
+# https://mypy.readthedocs.io/en/stable/runtime_troubles.html#using-new-additions-to-the-typing-module
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 
 class Comparable(Protocol):


### PR DESCRIPTION
Syntheseus previously depended on typing_extensions without specifying this in the `pyproject.toml` file, causing a fresh install to fail the tests. This PR fixes this by:

1. Wrapping the second import of typing_extensions in an if/else block to only run if python < 3.8 is used (otherwise an import from `typing` can be used directly). This was already present in the first import of typing_extensions.
2. Modify pyproject.toml to specify that `typing_extensions` is required, but _only if python < 3.8_.