### PR TITLE
Pin further Chemformer dependencies to avoid `torch` reinstallation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Pin further Chemformer dependencies to avoid `torch` reinstallation ([#108](https://github.com/microsoft/syntheseus/pull/108)) ([@kmaziarz])
 - Shift the `pandas` dependency to the external model packages ([#94](https://github.com/microsoft/syntheseus/pull/94)) ([@kmaziarz])
 - Fix constructor arguments in `ParallelReactionModel` ([#96](https://github.com/microsoft/syntheseus/pull/96)) ([@kmaziarz])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
   "pytest-cov",
   "pre-commit"
 ]
-chemformer = ["syntheseus-chemformer==0.1.1"]
+chemformer = ["syntheseus-chemformer==0.2.0"]
 graph2edits = ["syntheseus-graph2edits==0.2.0"]
 local-retro = ["syntheseus-local-retro==0.5.0"]
 megan = ["syntheseus-megan==0.1.0"]


### PR DESCRIPTION
Recently, the CI stopped working, as `pip`-installing `syntheseus[all]` started triggering a reinstallation of `torch`, despite the fact that we explicitly set up the right version of `torch` in the base environment (defined in `environment_full.yml`). A few weeks ago this was not the case (compare [successful CI run two weeks ago](https://github.com/microsoft/syntheseus/actions/runs/11680810734/job/32524601493) vs [failed one yesterday](https://github.com/microsoft/syntheseus/actions/runs/11944305673/job/33295026624)). This is caused by `torchmetrics` having been [recently updated to 1.6.0](https://pypi.org/project/torchmetrics/#history); despite the fact that `syntheseus-chemformer` pins its `pytorch-lightning` dependency, the latter seemingly doesn't pin `torchmetrics`, as we started getting the new version after it was released, which in turn is not compatible with the version of `torch` we use, prompting a reinstallation, and causing other dependencies (notably `torch-scatter`) to end up in a broken state. The solution here is to add a pin for `torchmetrics`, which I've done in the `syntheseus-chemformer` package and released as `0.2.0`.