### PR TITLE
Install `torch_scatter` from conda instead of pip

### DIFF
--- a/environment_full.yml
+++ b/environment_full.yml
@@ -3,13 +3,15 @@ channels:
   - defaults
   - conda-forge
   - pytorch
-  - dglteam       # LocalRetro, RetroKNN
+  - dglteam                 # LocalRetro, RetroKNN
+  - pyg                     # RetroKNN
 dependencies:
-  - dgl-cuda11.3  # LocalRetro, RetroKNN
-  - faiss-gpu     # RetroKNN
+  - dgl-cuda11.3            # LocalRetro, RetroKNN
+  - faiss-gpu               # RetroKNN
   - numpy
   - pip
   - python==3.9.7
   - pytorch=1.10.2=py3.9_cuda11.3_cudnn8.2.0_0
-  - rdchiral_cpp  # MHNreact
+  - pytorch-scatter==2.0.9  # RetroKNN
+  - rdchiral_cpp            # MHNreact
   - rdkit=2021.09.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ graph2edits = ["syntheseus-graph2edits==0.2.0"]
 local-retro = ["syntheseus-local-retro==0.5.0"]
 megan = ["syntheseus-megan==0.1.0"]
 mhn-react = ["syntheseus-mhnreact==1.0.0"]
-retro-knn = ["syntheseus[local-retro]", "torch-scatter"]
+retro-knn = ["syntheseus[local-retro]"]
 root-aligned = ["syntheseus-root-aligned==0.1.0"]
 all-single-step = [
   "syntheseus[chemformer,graph2edits,local-retro,megan,mhn-react,retro-knn,root-aligned]"


### PR DESCRIPTION
As highlighted by DocMinus in #106, our installation instructions can fail due to issues with `torch_scatter`. This is because our current setup is essentially equivalent to `pip install torch-scatter`, which compiles the library from source, and so depends on having the right versions of `nvcc` and `gcc`. Alternatively, we could specify an exact wheel from `https://data.pyg.org/whl/`, but that makes things a bit less portable and harder to switch between different Python versions. Instead, this PR shifts the `torch_scatter` dependency to use `pyg`'s conda channel as opposed to installation through `pip`.