### PR TITLE
Fix link to installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ conda activate syntheseus-full
 pip install "syntheseus[all]"
 ```
 
-See [here](https://microsoft.github.io/syntheseus/installation) if you prefer a more lightweight installation that only includes the parts you actually need.
+See [here](https://microsoft.github.io/syntheseus/stable/installation) if you prefer a more lightweight installation that only includes the parts you actually need.
 
 ## Citation and usage
 


### PR DESCRIPTION
As mentioned in #106, one of the docs links in README was missing the part that specifies the version, and thus it defaulted to a stale version from before #77. This PR fixes the link.