### PR TITLE
Fix search CLI crash under Python 3.11+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     defaults:
       run:
         shell: bash -l {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Drop support for Python 3.7 ([#113](https://github.com/microsoft/syntheseus/pull/113)) ([@kmaziarz])
 
+### Fixed
+
+- Fix search CLI crash under Python 3.11+ ([#114](https://github.com/microsoft/syntheseus/pull/114)) ([@kmaziarz])
+
 ## [0.5.0] - 2024-11-28
 
 ### Changed

--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -134,9 +134,9 @@ class BaseSearchConfig:
 
     # Fields configuring the search algorithm
     search_algorithm: str = "retro_star"  # "retro_star", "mcts", or "pdvn"
-    retro_star_config: RetroStarConfig = RetroStarConfig()
-    mcts_config: MCTSConfig = MCTSConfig()
-    pdvn_config: PDVNConfig = PDVNConfig()
+    retro_star_config: RetroStarConfig = field(default_factory=RetroStarConfig)
+    mcts_config: MCTSConfig = field(default_factory=MCTSConfig)
+    pdvn_config: PDVNConfig = field(default_factory=PDVNConfig)
 
     # Fields configuring what to save after the run
     save_graph: bool = True  # Whether to save the full reaction graph (can be large)


### PR DESCRIPTION
Some of the configuration options in the search CLI use mutable dataclasses as defaults; for some reason, this is only detected by Python 3.11 onwards, therefore our CI running under 3.7 - 3.9 did not flag it, but under Python 3.11 the search CLI crashes with an error. What's worse, one of our environment files (`environment.yml`) did not pin the version of Python, leading to 3.13 being selected, under which the error is present.

This PR makes the following changes:
- Use the `field` constructor instead of mutable defaults to restore proper behaviour under all Python versions.
- Run the CI under all Python versions ranging from 3.8 to 3.13 (the last stable version). In theory, it would likely be enough to test under 3.8 (oldest supported), 3.9 (used by single-step models) and 3.13 (newest supported). On the other hand, the core tests are fast and run in parallel, so testing under all versions shouldn't significantly increase time taken to merge PRs. Having more CI variants increases the chance that we hit some test flakiness and need to rerun a subset of the CIs, but if anything this will motivate us to fix the flaky tests.