### PR TITLE
Fix CI failure during mamba setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: test-core (Python ${{ matrix.python-version }})
     steps:
     - uses: actions/checkout@v3
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         mamba-version: "*"
         channels: conda-forge,defaults
@@ -53,7 +53,7 @@ jobs:
     - name: Free extra disk space
       uses: jlumbroso/free-disk-space@main
     - uses: actions/checkout@v3
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         mamba-version: "*"
         channels: conda-forge,defaults


### PR DESCRIPTION
Recently, our CI started failing from `main` due to issues during mamba setup. While it's not clear to me why that is the case, we've so far been using v2 of the `setup-miniconda` action, and simply bumping that to the newest v3 makes the problem go away; this is what's done in this PR.

There is no CHANGELOG entry added as this is a change purely on the CI side and it would not be visible to downstream users.