### PR TITLE
Add a utility to load a `SmilesListInventory` from file

### DIFF
--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -194,10 +194,8 @@ def run_from_config(config: SearchConfig) -> Path:
     )
 
     # Set up the inventory
-    with open(config.inventory_smiles_file, "rt") as f_inventory:
-        inventory_smiles = [line.strip() for line in f_inventory]
-    mol_inventory = SmilesListInventory(
-        inventory_smiles, canonicalize=config.canonicalize_inventory
+    mol_inventory = SmilesListInventory.load_from_file(
+        config.inventory_smiles_file, canonicalize=config.canonicalize_inventory
     )
 
     alg_kwargs: Dict[str, Any] = dict(reaction_model=search_rxn_model, mol_inventory=mol_inventory)

--- a/syntheseus/search/mol_inventory.py
+++ b/syntheseus/search/mol_inventory.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Collection
+from pathlib import Path
+from typing import Union
 
 from syntheseus.interface.molecule import Molecule
 
@@ -52,3 +54,9 @@ class SmilesListInventory(ExplicitMolInventory):
 
     def purchasable_mols(self) -> Collection[Molecule]:
         return self._mol_set
+
+    @classmethod
+    def load_from_file(cls, path: Union[str, Path], **kwargs) -> SmilesListInventory:
+        """Load the inventory SMILES from a file."""
+        with open(path, "rt") as f_inventory:
+            return cls([line.strip() for line in f_inventory], **kwargs)


### PR DESCRIPTION
By far the most common way to provide a purchasable molecule inventory is `SmilesListInventory`, and the most common way of constructing that is from a file containing a list of SMILES, one per line. So far, the code to read the SMILES, strip endlines, and construct the inventory, lived in the search CLI. However, calling search from arbitrary Python I had to duplicate it. This PR avoids this (minor) duplication by making this code a `classmethod` of `SmilesListInventory`.