### PR TITLE
Avoid pip 25.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,6 @@ channels:
   - defaults
 dependencies:
   - numpy
-  - pip
+  - pip<25.1
   - python>=3.8  # ideally 3.9+
   - rdkit

--- a/environment_full.yml
+++ b/environment_full.yml
@@ -9,7 +9,7 @@ dependencies:
   - dgl-cuda11.3            # LocalRetro, RetroKNN
   - faiss-gpu               # RetroKNN
   - numpy
-  - pip
+  - pip<25.1
   - python==3.9.7
   - pytorch=1.10.2=py3.9_cuda11.3_cudnn8.2.0_0
   - pytorch-scatter==2.0.9  # RetroKNN


### PR DESCRIPTION
Recently, our CI started failing with a mysterious error

```python
File "/usr/share/miniconda/envs/test/lib/python3.9/urllib/request.py", line 641, in http_error_default
  raise HTTPError(req.full_url, code, msg, hdrs, fp)

urllib.error.HTTPError: HTTP Error 403: SSL is required
```

It is quite elusive, but empirically seems to be related to self-referential extras in `pyproject.toml` (i.e. defining `syntheseus[X]` as a dependency for `syntheseus[Y]`), which we use to avoid listing the same dependency several times:
```
viz = [
  "pillow",
  "graphviz"
]
(...)
root-aligned = ["syntheseus-root-aligned==0.1.0"]
all-single-step = [
  "syntheseus[chemformer,graph2edits,local-retro,megan,mhn-react,retro-knn,root-aligned]"
]
all = [
  "syntheseus[viz,dev,all-single-step]"
]
```
This is a fairly new feature of `pip`, and not a very well-documented one. [Some report it started working in `pip 21.2`](https://github.com/pypa/pip/issues/11296), although changelogs don't mention it explicitly. Ever since we started picking up `pip 25.1` instead of `pip 25.0`, the build stopped working. I verified that this can be fixed by _either_ pinning to `pip 25.1` _or_ unrolling the self-referential extras to duplicate all the dependencies (e.g. explicitly writing down `syntheseus-root-aligned==0.1.0` as part of `root-aligned`, `all-single-step` and `all`).

It seems slightly better to temporarily avoid the newest `pip` (and hope the issue gets resolved downstream) instead of cluttering our `pyproject.toml` with a (now legacy) duplication pattern; hence this PR does the former in an attempt to get CI working again.