### PR TITLE
Refactor search CLI to make it easier to access programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Drop support for Python 3.7 ([#113](https://github.com/microsoft/syntheseus/pull/113)) ([@kmaziarz])
+- Refactor search CLI to make it easier to access programmatically ([#126](https://github.com/microsoft/syntheseus/pull/126)) ([@kmaziarz])
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Drop support for Python 3.7 ([#113](https://github.com/microsoft/syntheseus/pull/113)) ([@kmaziarz])
 
+### Added
+
+- Add a utility to load a `SmilesListInventory` from file ([#124](https://github.com/microsoft/syntheseus/pull/124)) ([@kmaziarz])
+
 ### Fixed
 
 - Fix search CLI crash under Python 3.11+ ([#114](https://github.com/microsoft/syntheseus/pull/114)) ([@kmaziarz])

--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -115,14 +115,11 @@ class SearchAlgorithmClass(Enum):
 
 
 @dataclass
-class BaseSearchConfig:
-    # Molecule(s) to search for (either as a single explicit SMILES or a file)
-    search_target: str = MISSING
-    search_targets_file: str = MISSING
-
-    inventory_smiles_file: str = MISSING  # Purchasable molecules
-    results_dir: str = "."  # Directory to save the results in
-    append_timestamp_to_dir: bool = True  # Whether to append the current time to directory name
+class SearchAlgorithmConfig:
+    search_algorithm: SearchAlgorithmClass = SearchAlgorithmClass.retro_star
+    retro_star_config: RetroStarConfig = field(default_factory=RetroStarConfig)
+    mcts_config: MCTSConfig = field(default_factory=MCTSConfig)
+    pdvn_config: PDVNConfig = field(default_factory=PDVNConfig)
 
     # By default limit search time (but set very high iteration limits just in case)
     time_limit_s: float = 600
@@ -132,18 +129,23 @@ class BaseSearchConfig:
     prevent_repeat_mol_in_trees: bool = True
     stop_on_first_solution: bool = False
 
+
+@dataclass
+class BaseSearchConfig(SearchAlgorithmConfig):
+    # Molecule(s) to search for (either as a single explicit SMILES or a file)
+    search_target: str = MISSING
+    search_targets_file: str = MISSING
+
+    inventory_smiles_file: str = MISSING  # Purchasable molecules
+    results_dir: str = "."  # Directory to save the results in
+    append_timestamp_to_dir: bool = True  # Whether to append the current time to directory name
+
     use_gpu: bool = True  # Whether to use a GPU
     canonicalize_inventory: bool = False  # Whether to canonicalize the inventory SMILES
 
     # Fields configuring the reaction model (on top of the arguments from `BackwardModelConfig`)
     num_top_results: int = 50  # Number of results to request
     reaction_model_use_cache: bool = True  # Whether to cache the results
-
-    # Fields configuring the search algorithm
-    search_algorithm: SearchAlgorithmClass = SearchAlgorithmClass.retro_star
-    retro_star_config: RetroStarConfig = field(default_factory=RetroStarConfig)
-    mcts_config: MCTSConfig = field(default_factory=MCTSConfig)
-    pdvn_config: PDVNConfig = field(default_factory=PDVNConfig)
 
     # Fields configuring what to save after the run
     save_graph: bool = True  # Whether to save the full reaction graph (can be large)

--- a/syntheseus/tests/cli/test_search.py
+++ b/syntheseus/tests/cli/test_search.py
@@ -54,7 +54,7 @@ def test_resume_search(tmpdir: Path) -> None:
     config = OmegaConf.create(  # type: ignore
         SearchConfig(
             model_class="FlakyReactionModel",  # type: ignore[arg-type]
-            search_algorithm="retro_star",
+            search_algorithm="retro_star",  # type: ignore[arg-type]
             search_targets_file=str(search_targets_file_path),
             inventory_smiles_file=str(inventory_file_path),
             results_dir=str(tmpdir),


### PR DESCRIPTION
Our search CLI has so far been structured in a way that makes it hard to call parts of it programmatically from outside; for example, the code to parse and reorganize search algorithm hyperparameters was only present inside `run_from_config`. This PR refactors things to extract this logic out, and also separates arguments configuring the search algorithm itself from other configuration options. Finally, it also changes the type of the `search_algorithm` argument from `str` to an appropriate `Enum`, which allows for failing slightly earlier when an unsupported algorithm has been selected. Changes are split into reasonable commits for easier reviewing.