### PR TITLE
Support LRU cache eviction for reaction models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Support LRU cache eviction for reaction models ([#127](https://github.com/microsoft/syntheseus/pull/127)) ([@kmaziarz])
 - Add a utility to load a `SmilesListInventory` from file ([#124](https://github.com/microsoft/syntheseus/pull/124)) ([@kmaziarz])
 
 ### Fixed

--- a/syntheseus/tests/conftest.py
+++ b/syntheseus/tests/conftest.py
@@ -14,6 +14,18 @@ def cocs_mol() -> Molecule:
 
 
 @pytest.fixture
+def ossc_mol() -> Molecule:
+    """Returns the molecule with smiles 'OSSC'."""
+    return Molecule("OSSC", make_rdkit_mol=False)
+
+
+@pytest.fixture
+def soos_mol() -> Molecule:
+    """Returns the molecule with smiles 'SOOS'."""
+    return Molecule("SOOS", make_rdkit_mol=False)
+
+
+@pytest.fixture
 def rxn_cocs_from_co_cs(cocs_mol: Molecule) -> SingleProductReaction:
     """Returns a reaction with COCS as the product."""
     return SingleProductReaction(product=cocs_mol, reactants=Bag([Molecule("CO"), Molecule("CS")]))


### PR DESCRIPTION
Our base `ReactionModel` class implements simple caching, which avoids calling the model multiple times with the same input. However, there is no way to limit the growth of said cache, which can be problematic in longer-running deployments (e.g. server which runs indefinitely and accepts single-step or multi-step requests). This PR adds support for LRU-style cache eviction, which can be enabled by setting the `max_cache_size` parameter in the constructor.