### PR TITLE
Rerun random search test in case of failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ viz = [
 dev = [
   "pytest",
   "pytest-cov",
+  "pytest-rerunfailures",
   "pre-commit"
 ]
 chemformer = ["syntheseus-chemformer==0.2.0"]

--- a/syntheseus/tests/search/algorithms/test_random.py
+++ b/syntheseus/tests/search/algorithms/test_random.py
@@ -25,6 +25,7 @@ class BaseRandomSearchTest(BaseAlgorithmTest):
     def test_found_routes2(self, retrosynthesis_task2: RetrosynthesisTask) -> None:
         pass
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.parametrize("limit", [0, 1, 2, 1000])
     def test_limit_iterations(
         self,


### PR DESCRIPTION
The `test_limit_iterations` test does fail occasionally for random search algorithms (in 1-2% of cases); given that we test across 6 Python versions, the overall CI does fail in a non-negligible fraction of cases. One option would be to increase the limit on the number of iterations from 1000 to 2000 - 3000, but even that doesn't drive the failure probability as low as one could hope for. Alternatively, in this PR I propose using the `pytest-rerunfailures` plug-in, and judging the test as failed if it fails 3 times in a row. In theory the probability of this should be the original probability cubed, so less than 0.001%.