### PR TITLE
Implement option to expand target even when purchasable

### DIFF
--- a/syntheseus/search/algorithms/base.py
+++ b/syntheseus/search/algorithms/base.py
@@ -73,6 +73,7 @@ class SearchAlgorithm(MinimalSearchAlgorithm[GraphType, AlgReturnType]):
         limit_graph_nodes: int = INT_INF,
         time_limit_s: float = math.inf,
         max_expansion_depth: int = 50,
+        expand_purchasable_target: bool = False,
         expand_purchasable_mols: bool = False,
         set_depth: bool = True,
         set_has_solution: bool = True,
@@ -89,6 +90,7 @@ class SearchAlgorithm(MinimalSearchAlgorithm[GraphType, AlgReturnType]):
         self.limit_graph_nodes = limit_graph_nodes
         self.time_limit_s = time_limit_s
         self.max_expansion_depth = max_expansion_depth
+        self.expand_purchasable_target = expand_purchasable_target
         self.expand_purchasable_mols = expand_purchasable_mols
         self.set_depth = set_depth
         self.set_has_solution = set_has_solution
@@ -183,7 +185,11 @@ class SearchAlgorithm(MinimalSearchAlgorithm[GraphType, AlgReturnType]):
         )
 
     def should_expand_mol(self, mol: Molecule, graph: GraphType) -> bool:
-        return self.expand_purchasable_mols or not mol.metadata["is_purchasable"]
+        return (
+            self.expand_purchasable_mols
+            or not mol.metadata["is_purchasable"]
+            or (self.expand_purchasable_target and mol == graph.root_mol)
+        )
 
     def set_node_values(
         self, nodes: Collection[BaseGraphNode], graph: GraphType

--- a/syntheseus/search/algorithms/base.py
+++ b/syntheseus/search/algorithms/base.py
@@ -182,6 +182,9 @@ class SearchAlgorithm(MinimalSearchAlgorithm[GraphType, AlgReturnType]):
             or (self.stop_on_first_solution and graph.root_node.has_solution)
         )
 
+    def should_expand_mol(self, mol: Molecule, graph: GraphType) -> bool:
+        return self.expand_purchasable_mols or not mol.metadata["is_purchasable"]
+
     def set_node_values(
         self, nodes: Collection[BaseGraphNode], graph: GraphType
     ) -> Collection[BaseGraphNode]:
@@ -307,7 +310,7 @@ class AndOrSearchAlgorithm(SearchAlgorithm[AndOrGraph, AlgReturnType], Generic[A
     def _get_mols_to_expand(self, node: BaseGraphNode, graph: AndOrGraph) -> Collection[Molecule]:
         output: list[Molecule] = []
         if isinstance(node, OrNode):
-            if self.expand_purchasable_mols or not node.mol.metadata["is_purchasable"]:
+            if self.should_expand_mol(node.mol, graph):
                 output.append(node.mol)
         return output
 
@@ -362,7 +365,7 @@ class MolSetSearchAlgorithm(SearchAlgorithm[MolSetGraph, AlgReturnType], Generic
         output: list[Molecule] = []
         assert isinstance(node, MolSetNode)
         for mol in node.mols:
-            if self.expand_purchasable_mols or not mol.metadata["is_purchasable"]:
+            if self.should_expand_mol(mol, graph):
                 output.append(mol)
         return output
 

--- a/syntheseus/tests/search/conftest.py
+++ b/syntheseus/tests/search/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import collections
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 
 import pytest
 
@@ -249,6 +249,23 @@ def retrosynthesis_task6() -> RetrosynthesisTask:
         reaction_model=LinearMoleculesToyModel(allow_substitution=True, use_cache=True),
         inventory=SmilesListInventory(["CCCO", "CC", "COC", "O"]),
     )
+
+
+@pytest.fixture
+def retrosynthesis_task7(retrosynthesis_task1: RetrosynthesisTask) -> RetrosynthesisTask:
+    """
+    Variation on `retrosynthesis_task1` in which the target is already purchasable.
+
+    If one expands the target anyway, it can be solved in one step.
+    """
+
+    data = {f.name: getattr(retrosynthesis_task1, f.name) for f in fields(retrosynthesis_task1)}
+    new_inventory = SmilesListInventory(
+        [mol.smiles for mol in retrosynthesis_task1.inventory.purchasable_mols()]
+        + [retrosynthesis_task1.target_mol.smiles]
+    )
+
+    return RetrosynthesisTask(**data | {"inventory": new_inventory})
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR implements an `expand_purchasable_target` option, which forces the search algorithm to expand the target molecule, even if it is already purchasable. This is similar to `exclude_target_from_stock` from [aizynthfinder](https://molecularai.github.io/aizynthfinder/configuration.html). The implementation is similar to the existing `expand_purchasable_mols`: purchasability metadata is still set according to the full inventory, but if the option is set then expansion happens regardless.

For the record, I also considered (but rejected) two alternative ways of implementing this feature:
- Taking `aizynthfinder`'s naming literally by temporarily removing the target from the inventory. Although an abstract inventory does not necessarily hold a collection of purchasable molecules inside, I considered adding `exclude(Molecule)` and `clear_exclusions()` methods to `BaseMolInventory` to handle these "temporary exclusions". However, this would make the inventory class mutable, which would go against the implicit assumption of immutability our search algorithms seem to make. It would also mean we'd have to be extra careful to remove the exclusions after search is done (e.g. when search is interrupted with an exception, which is then caught, we don't want the inventory to be left in a broken state).
- Overriding the purchasability metadata received from the inventory when the molecule is the target, to have it marked as non-purchasable, as if it was not in the inventory to begin with. This is inconsistent with the behaviour of `expand_purchasable_mols`, and would mean the metadata on the molecules may not agree with the state of the inventory.