### PR TITLE
Pin `sentencepiece` to `0.2.0` in the RootAligned dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ local-retro = ["syntheseus-local-retro==0.5.0"]
 megan = ["syntheseus-megan==0.1.0"]
 mhn-react = ["syntheseus-mhnreact==1.0.0"]
 retro-knn = ["syntheseus[local-retro]"]
-root-aligned = ["syntheseus-root-aligned==0.1.0"]
+root-aligned = ["syntheseus-root-aligned==0.2.0"]
 all-single-step = [
   "syntheseus[chemformer,graph2edits,local-retro,megan,mhn-react,retro-knn,root-aligned]"
 ]


### PR DESCRIPTION
Recently we had issues with the `0.2.1` update to `sentencepiece` (which RootAligned depends on), causing environments depending on `syntheseus-root-aligned` to stop building in certain contexts (not in GitHub CI for this repo though). Nevertheless, I updated `syntheseus-root-aligned` to pin `sentencepiece==0.2.0` which is what we've been using previously; this PR pulls that in into `syntheseus`.