### PR TITLE
Release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-01-30
+
 ### Fixed
 
 - Fix automatic checkpoint download ([#146](https://github.com/microsoft/syntheseus/pull/146)) ([@kmaziarz])
@@ -148,7 +150,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 :seedling: Initial public release, containing several multi-step search algorithms and a minimal interface for single-step models.
 
-[Unreleased]: https://github.com/microsoft/syntheseus/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/microsoft/syntheseus/compare/v0.7.2...HEAD
 [0.1.0]: https://github.com/microsoft/syntheseus/releases/tag/v0.1.0
 [0.2.0]: https://github.com/microsoft/syntheseus/releases/tag/v0.2.0
 [0.3.0]: https://github.com/microsoft/syntheseus/releases/tag/v0.3.0
@@ -158,6 +160,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 [0.6.0]: https://github.com/microsoft/syntheseus/releases/tag/v0.6.0
 [0.7.0]: https://github.com/microsoft/syntheseus/releases/tag/v0.7.0
 [0.7.1]: https://github.com/microsoft/syntheseus/releases/tag/v0.7.1
+[0.7.2]: https://github.com/microsoft/syntheseus/releases/tag/v0.7.2
 
 [@austint]: https://github.com/AustinT
 [@kmaziarz]: https://github.com/kmaziarz


### PR DESCRIPTION
This PR edits the CHANGELOG to mark the release of `v0.7.2`. This is a small bugfix release to fix automatic checkpoint downloading, which broke recently due to upstream changes.