### PR TITLE
Filter reactions where one of the reactants is the product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add option to filter out reactions where the product is also one of the reactants ([#148](https://github.com/microsoft/syntheseus/pull/148)) ([@jla-gardner])
 - Integrate the RetroChimera model ([#156](https://github.com/microsoft/syntheseus/pull/156)) ([@kmaziarz])
 - Implement resumability for single-step evaluations ([#149](https://github.com/microsoft/syntheseus/pull/149), [#155](https://github.com/microsoft/syntheseus/pull/155)) ([@jla-gardner], [@kmaziarz])
 - Add abstractions for filtering backward model proposals ([#151](https://github.com/microsoft/syntheseus/pull/151)) ([@kmaziarz])
 - Pass molecule creation options through `molecule_bag_to_smiles` ([#152](https://github.com/microsoft/syntheseus/pull/152)) ([@kmaziarz])
+- Add option to filter out reactions where the product is also one of the reactants ([#148](https://github.com/microsoft/syntheseus/pull/148)) ([@jla-gardner])
 
 ## [0.7.2] - 2026-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add option to filter out reactions where the product is also one of the reactants ([#148](https://github.com/microsoft/syntheseus/pull/148)) ([@jla-gardner])
 - Integrate the RetroChimera model ([#156](https://github.com/microsoft/syntheseus/pull/156)) ([@kmaziarz])
 - Implement resumability for single-step evaluations ([#149](https://github.com/microsoft/syntheseus/pull/149), [#155](https://github.com/microsoft/syntheseus/pull/155)) ([@jla-gardner], [@kmaziarz])
 - Add abstractions for filtering backward model proposals ([#151](https://github.com/microsoft/syntheseus/pull/151)) ([@kmaziarz])

--- a/syntheseus/interface/models.py
+++ b/syntheseus/interface/models.py
@@ -153,12 +153,14 @@ class ReactionModel(
         self,
         *,
         remove_duplicates: bool = True,
+        remove_product_in_reactants: bool = False,
         default_num_results: int = DEFAULT_NUM_RESULTS,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.default_num_results = default_num_results
         self._remove_duplicates = remove_duplicates
+        self._remove_product_in_reactants = remove_product_in_reactants
 
     def __call__(
         self, inputs: list[InputType], num_results: Optional[int] = None
@@ -203,13 +205,16 @@ class ReactionModel(
 
     def filter_reactions(self, reaction_list: Sequence[ReactionType]) -> Sequence[ReactionType]:
         """
-        Filters a list of reactions. In the base version this just removes duplicates,
-        but subclasses could add additional behaviour or override this.
+        Filters a list of reactions. In the base version this just removes (i) duplicates,
+        and (ii) reactions where the product is also in the reactants (if the corresponding
+        flags are set), but subclasses could add additional behaviour or override this.
         """
+        output: Sequence[ReactionType] = list(reaction_list)
+        if self._remove_product_in_reactants:
+            output = [rxn for rxn in output if rxn.unique_products.isdisjoint(rxn.unique_reactants)]
         if self._remove_duplicates:
-            return deduplicate_keeping_order(reaction_list)
-        else:
-            return list(reaction_list)
+            output = deduplicate_keeping_order(output)
+        return output
 
     def get_model_info(self) -> dict[str, Any]:
         return {}

--- a/syntheseus/tests/interface/test_models.py
+++ b/syntheseus/tests/interface/test_models.py
@@ -13,6 +13,22 @@ from syntheseus.reaction_prediction.inference.toy_models import LinearMoleculesT
 
 
 @pytest.mark.parametrize("remove", [True, False])
+def test_remove_product_in_reactants(remove: bool) -> None:
+    """Test that reactions where a product appears in the reactants are filtered out."""
+    product = Molecule("CC")
+    good_rxn = SingleProductReaction(product=product, reactants=Bag({Molecule("C"), Molecule("O")}))
+    bad_rxn = SingleProductReaction(product=product, reactants=Bag({product, Molecule("O")}))
+
+    model = LinearMoleculesToyModel(remove_duplicates=False, remove_product_in_reactants=remove)
+    filtered = model.filter_reactions([good_rxn, bad_rxn])
+
+    if remove:
+        assert list(filtered) == [good_rxn]
+    else:
+        assert list(filtered) == [good_rxn, bad_rxn]
+
+
+@pytest.mark.parametrize("remove", [True, False])
 def test_remove_duplicates(remove: bool) -> None:
     """
     Test the 'remove_duplicates' kwarg by calling the LinearMolecules model on "CC".


### PR DESCRIPTION
This PR add an option to all reaction models to filter out reactions where the product is also one of the reactants. This is hidden behind a flag `remove_product_in_reactants`, which is `False` by default for backwards compatibility.