### PR TITLE
Implement resumable single step evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Implement resumability for single-step evaluations ([#149](https://github.com/microsoft/syntheseus/pull/149)) ([@jla-gardner])  
+- Implement resumability for single-step evaluations ([#149](https://github.com/microsoft/syntheseus/pull/149)) ([@jla-gardner])
 
 ## [0.7.2] - 2026-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add a `resumable` flag when running single step predictions. By default this is set to False, preserving existing behaviour. If this is turned on, single step results for each input are saved to disk in a JSON-lines file, such that if a job is killed halfway through, running the same command will resume from the state the previous run reached. ([#149](https://github.com/microsoft/syntheseus/pull/149)) ([@jla-gardner])
+
 ## [0.7.2] - 2026-01-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Implement resumability for single-step evaluations. ([#149](https://github.com/microsoft/syntheseus/pull/149)) ([@jla-gardner])
+- Implement resumability for single-step evaluations ([#149](https://github.com/microsoft/syntheseus/pull/149)) ([@jla-gardner])  
 
 ## [0.7.2] - 2026-01-30
 
@@ -170,3 +170,4 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 [@kmaziarz]: https://github.com/kmaziarz
 [@jagarridotorres]: https://github.com/jagarridotorres
 [@fiberleif]: https://github.com/fiberleif
+[@jla-gardner]: https://github.com/jla-gardner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add a `resumable` flag when running single step predictions. By default this is set to False, preserving existing behaviour. If this is turned on, single step results for each input are saved to disk in a JSON-lines file, such that if a job is killed halfway through, running the same command will resume from the state the previous run reached. ([#149](https://github.com/microsoft/syntheseus/pull/149)) ([@jla-gardner])
+- Implement resumability for single-step evaluations. ([#149](https://github.com/microsoft/syntheseus/pull/149)) ([@jla-gardner])
 
 ## [0.7.2] - 2026-01-30
 

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -216,7 +216,8 @@ class TimingRecord:
 class PredictionRecord:
     """Schema for a single row in the resumable predictions JSONL file."""
 
-    target: str
+    input: str
+    ground_truth: str
     num_predictions: int
     ground_truth_correct: List[bool]
     timing: TimingRecord
@@ -229,7 +230,8 @@ class PredictionRecord:
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to a JSON-compatible dict, omitting unset optional fields."""
         d: Dict[str, Any] = {
-            "target": self.target,
+            "input": self.input,
+            "ground_truth": self.ground_truth,
             "num_predictions": self.num_predictions,
             "ground_truth_correct": self.ground_truth_correct,
             "timing": asdict(self.timing),
@@ -250,7 +252,8 @@ class PredictionRecord:
         """Deserialize from a JSON-loaded dict."""
         bt_timing = d.get("back_translation_timing")
         return cls(
-            target=d.get("target", ""),
+            input=d.get("input", ""),
+            ground_truth=d.get("ground_truth", ""),
             num_predictions=d["num_predictions"],
             ground_truth_correct=d["ground_truth_correct"],
             timing=TimingRecord(**d["timing"]),
@@ -509,8 +512,14 @@ def compute_metrics(
                         bt_preds = [
                             [rxn.reaction_smiles for rxn in seq] for seq in back_translation_results
                         ]
+                if isinstance(input, Molecule):
+                    input_smiles = input.smiles
+                else:
+                    assert isinstance(input, Bag)
+                    input_smiles = ".".join(mol.smiles for mol in input)
                 record = PredictionRecord(
-                    target=output.reaction_smiles,
+                    input=input_smiles,
+                    ground_truth=output.reaction_smiles,
                     num_predictions=len(reaction_list),
                     ground_truth_correct=ground_truth_matches,
                     timing=TimingRecord(

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -36,8 +36,8 @@ from syntheseus.interface.models import (
     ReactionModel,
     ReactionType,
 )
-from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule
-from syntheseus.interface.reaction import REACTION_SEPARATOR, Reaction, SingleProductReaction
+from syntheseus.interface.molecule import Molecule, molecule_bag_to_smiles
+from syntheseus.interface.reaction import Reaction, SingleProductReaction
 from syntheseus.reaction_prediction.chem.utils import remove_stereo_information_from_reaction
 from syntheseus.reaction_prediction.data.dataset import (
     DataFold,
@@ -50,12 +50,8 @@ from syntheseus.reaction_prediction.inference.config import (
     BackwardModelConfig,
     ForwardModelConfig,
 )
-from syntheseus.reaction_prediction.utils.config import (
-    get_config as cli_get_config,
-)
-from syntheseus.reaction_prediction.utils.config import (
-    get_error_message_for_missing_value,
-)
+from syntheseus.reaction_prediction.utils.config import get_config as cli_get_config
+from syntheseus.reaction_prediction.utils.config import get_error_message_for_missing_value
 from syntheseus.reaction_prediction.utils.metrics import (
     ModelTimingResults,
     TopKMetricsAccumulator,
@@ -205,14 +201,6 @@ def get_results(
 
 
 @dataclass(frozen=True)
-class TimingRecord:
-    """Timing information for a single sample's model call."""
-
-    time_model_call: float
-    time_post_processing: float
-
-
-@dataclass(frozen=True)
 class PredictionRecord:
     """Schema for a single row in the resumable predictions JSONL file."""
 
@@ -220,58 +208,29 @@ class PredictionRecord:
     ground_truth: str
     num_predictions: int
     ground_truth_correct: List[bool]
-    timing: TimingRecord
+    timing: ModelTimingResults
     stereo_correct: Optional[List[bool]] = None
     back_translation_correct: Optional[List[bool]] = None
-    back_translation_timing: Optional[TimingRecord] = None
+    back_translation_timing: Optional[ModelTimingResults] = None
     predictions: Optional[List[str]] = None
     back_translation_predictions: Optional[List[List[str]]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to a JSON-compatible dict, omitting unset optional fields."""
-        d: Dict[str, Any] = {
-            "input": self.input,
-            "ground_truth": self.ground_truth,
-            "num_predictions": self.num_predictions,
-            "ground_truth_correct": self.ground_truth_correct,
-            "timing": asdict(self.timing),
-        }
-        if self.stereo_correct is not None:
-            d["stereo_correct"] = self.stereo_correct
-        if self.back_translation_timing is not None:
-            d["back_translation_correct"] = self.back_translation_correct
-            d["back_translation_timing"] = asdict(self.back_translation_timing)
-        if self.predictions is not None:
-            d["predictions"] = self.predictions
-        if self.back_translation_predictions is not None:
-            d["back_translation_predictions"] = self.back_translation_predictions
+        d: Dict[str, Any] = {}
+        for f in fields(self):
+            val = getattr(self, f.name)
+            if val is None:
+                continue
+            d[f.name] = asdict(val) if f.name.endswith("timing") else val
         return d
 
     @classmethod
     def from_dict(cls, d: Dict[str, Any]) -> "PredictionRecord":
         """Deserialize from a JSON-loaded dict."""
-        bt_timing = d.get("back_translation_timing")
         return cls(
-            input=d.get("input", ""),
-            ground_truth=d.get("ground_truth", ""),
-            num_predictions=d["num_predictions"],
-            ground_truth_correct=d["ground_truth_correct"],
-            timing=TimingRecord(**d["timing"]),
-            stereo_correct=d.get("stereo_correct"),
-            back_translation_correct=d.get("back_translation_correct"),
-            back_translation_timing=TimingRecord(**bt_timing) if bt_timing else None,
-            predictions=d.get("predictions"),
-            back_translation_predictions=d.get("back_translation_predictions"),
+            **{k: ModelTimingResults(**v) if k.endswith("timing") else v for k, v in d.items()}  # type: ignore
         )
-
-
-def _reaction_from_smiles(rxn_smiles: str) -> Reaction:
-    """Reconstruct a Reaction from its reaction SMILES string."""
-    sep = REACTION_SEPARATOR * 2
-    reactants_str, products_str = rxn_smiles.split(sep)
-    reactants = Bag(Molecule(s) for s in reactants_str.split(SMILES_SEPARATOR) if s)
-    products = Bag(Molecule(s) for s in products_str.split(SMILES_SEPARATOR) if s)
-    return Reaction(reactants=reactants, products=products)
 
 
 def _load_and_fix_jsonl(path: Path) -> List[PredictionRecord]:
@@ -369,25 +328,15 @@ def compute_metrics(
                 assert rec.back_translation_correct is not None
                 back_translation_metrics.add(rec.back_translation_correct)
             num_predictions.append(rec.num_predictions)
-            model_timing_results.append(
-                ModelTimingResults(
-                    time_model_call=rec.timing.time_model_call,
-                    time_post_processing=rec.timing.time_post_processing,
-                )
-            )
+            model_timing_results.append(rec.timing)
             if rec.back_translation_timing is not None:
-                back_translation_timing_results.append(
-                    ModelTimingResults(
-                        time_model_call=rec.back_translation_timing.time_model_call,
-                        time_post_processing=rec.back_translation_timing.time_post_processing,
-                    )
-                )
+                back_translation_timing_results.append(rec.back_translation_timing)
             if include_predictions and rec.predictions is not None:
-                all_predictions.append([_reaction_from_smiles(s) for s in rec.predictions])
+                all_predictions.append([Reaction.from_reaction_smiles(s) for s in rec.predictions])
             if include_predictions and rec.back_translation_predictions is not None:
                 all_back_translation_predictions.append(
                     [
-                        [_reaction_from_smiles(s) for s in seq]
+                        [Reaction.from_reaction_smiles(s) for s in seq]
                         for seq in rec.back_translation_predictions
                     ]
                 )
@@ -498,13 +447,13 @@ def compute_metrics(
                 batch_len = len(batch)
                 t = results_with_timing.model_timing_results
                 bt_correct: Optional[List[bool]] = None
-                bt_timing: Optional[TimingRecord] = None
+                bt_timing: Optional[ModelTimingResults] = None
                 bt_preds: Optional[List[List[str]]] = None
                 if back_translation_model is not None:
                     bt = back_translation_results_with_timing.model_timing_results
                     assert bt is not None
                     bt_correct = back_translation_matches
-                    bt_timing = TimingRecord(
+                    bt_timing = ModelTimingResults(
                         time_model_call=bt.time_model_call / batch_len,
                         time_post_processing=bt.time_post_processing / batch_len,
                     )
@@ -516,13 +465,13 @@ def compute_metrics(
                     input_smiles = input.smiles
                 else:
                     assert isinstance(input, Bag)
-                    input_smiles = ".".join(mol.smiles for mol in input)
+                    input_smiles = molecule_bag_to_smiles(input)
                 record = PredictionRecord(
                     input=input_smiles,
                     ground_truth=output.reaction_smiles,
                     num_predictions=len(reaction_list),
                     ground_truth_correct=ground_truth_matches,
-                    timing=TimingRecord(
+                    timing=ModelTimingResults(
                         time_model_call=t.time_model_call / batch_len,
                         time_post_processing=t.time_post_processing / batch_len,
                     ),

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -57,7 +57,11 @@ from syntheseus.reaction_prediction.utils.metrics import (
     TopKMetricsAccumulator,
     compute_total_time,
 )
-from syntheseus.reaction_prediction.utils.misc import asdict_extended, set_random_seed
+from syntheseus.reaction_prediction.utils.misc import (
+    asdict_extended,
+    set_random_seed,
+    undictify_bag_of_molecules,
+)
 from syntheseus.reaction_prediction.utils.model_loading import get_model
 
 logger = logging.getLogger(__file__)
@@ -212,8 +216,8 @@ class PredictionRecord:
     stereo_correct: Optional[List[bool]] = None
     back_translation_correct: Optional[List[bool]] = None
     back_translation_timing: Optional[ModelTimingResults] = None
-    predictions: Optional[List[str]] = None
-    back_translation_predictions: Optional[List[List[str]]] = None
+    predictions: Optional[List[Dict[str, Any]]] = None
+    back_translation_predictions: Optional[List[List[Dict[str, Any]]]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to a JSON-compatible dict, omitting unset optional fields."""
@@ -246,6 +250,16 @@ def _load_and_fix_jsonl(path: Path) -> List[PredictionRecord]:
         for d in raw_dicts:
             f.write(json.dumps(d) + "\n")
     return [PredictionRecord.from_dict(d) for d in raw_dicts]
+
+
+def _reaction_from_dict(data: Dict[str, Any]) -> Reaction:
+    """Recover a reaction serialized with `asdict_extended`."""
+    return Reaction(
+        reactants=undictify_bag_of_molecules(data["reactants"]),
+        products=undictify_bag_of_molecules(data["products"]),
+        identifier=data.get("identifier"),
+        metadata=data.get("metadata", {}),
+    )
 
 
 def compute_metrics(
@@ -332,11 +346,11 @@ def compute_metrics(
             if rec.back_translation_timing is not None:
                 back_translation_timing_results.append(rec.back_translation_timing)
             if include_predictions and rec.predictions is not None:
-                all_predictions.append([Reaction.from_reaction_smiles(s) for s in rec.predictions])
+                all_predictions.append([_reaction_from_dict(d) for d in rec.predictions])
             if include_predictions and rec.back_translation_predictions is not None:
                 all_back_translation_predictions.append(
                     [
-                        [Reaction.from_reaction_smiles(s) for s in seq]
+                        [_reaction_from_dict(d) for d in seq]
                         for seq in rec.back_translation_predictions
                     ]
                 )
@@ -413,6 +427,10 @@ def compute_metrics(
                 ]
                 ground_truth_match_modulo_stereo_metrics.add(stereo_matches)
 
+            preds_for_output: Optional[List[Dict[str, Any]]] = None
+            if include_predictions:
+                preds_for_output = [asdict_extended(rxn) for rxn in reaction_list]
+
             if back_translation_model is not None:
                 assert back_translation_metrics is not None
 
@@ -430,7 +448,11 @@ def compute_metrics(
 
                 back_translation_results = back_translation_results_with_timing.results
 
+                bt_preds_for_output: Optional[List[List[Dict[str, Any]]]] = None
                 if include_predictions:
+                    bt_preds_for_output = [
+                        [asdict_extended(rxn) for rxn in seq] for seq in back_translation_results
+                    ]
                     batch_back_translation_predictions.append(back_translation_results)
 
                 # Back translation is successful if any of the `back_translation_num_results` bags
@@ -448,7 +470,7 @@ def compute_metrics(
                 t = results_with_timing.model_timing_results
                 bt_correct: Optional[List[bool]] = None
                 bt_timing: Optional[ModelTimingResults] = None
-                bt_preds: Optional[List[List[str]]] = None
+                bt_preds: Optional[List[List[Dict[str, Any]]]] = None
                 if back_translation_model is not None:
                     bt = back_translation_results_with_timing.model_timing_results
                     assert bt is not None
@@ -458,9 +480,7 @@ def compute_metrics(
                         time_post_processing=bt.time_post_processing / batch_len,
                     )
                     if include_predictions:
-                        bt_preds = [
-                            [rxn.reaction_smiles for rxn in seq] for seq in back_translation_results
-                        ]
+                        bt_preds = bt_preds_for_output
                 if isinstance(input, Molecule):
                     input_smiles = input.smiles
                 else:
@@ -478,11 +498,7 @@ def compute_metrics(
                     stereo_correct=stereo_matches,
                     back_translation_correct=bt_correct,
                     back_translation_timing=bt_timing,
-                    predictions=(
-                        [rxn.reaction_smiles for rxn in reaction_list]
-                        if include_predictions
-                        else None
-                    ),
+                    predictions=preds_for_output,
                     back_translation_predictions=bt_preds,
                 )
                 jsonl_file.write(json.dumps(record.to_dict()) + "\n")

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -18,9 +18,10 @@ import logging
 import math
 import os
 import time
-from dataclasses import dataclass, field, fields
+from dataclasses import asdict, dataclass, field, fields
 from functools import partial
 from itertools import islice
+from pathlib import Path
 from statistics import mean, median
 from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Sequence, Tuple, cast
 
@@ -28,13 +29,15 @@ from more_itertools import batched
 from omegaconf import MISSING, OmegaConf
 from tqdm import tqdm
 
+from syntheseus.interface.bag import Bag
 from syntheseus.interface.models import (
     ForwardReactionModel,
     InputType,
     ReactionModel,
     ReactionType,
 )
-from syntheseus.interface.reaction import Reaction, SingleProductReaction
+from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule
+from syntheseus.interface.reaction import REACTION_SEPARATOR, Reaction, SingleProductReaction
 from syntheseus.reaction_prediction.chem.utils import remove_stereo_information_from_reaction
 from syntheseus.reaction_prediction.data.dataset import (
     DataFold,
@@ -67,6 +70,8 @@ logger = logging.getLogger(__file__)
 _RXN_WTIH_IDENTIFIER_ERROR = (
     "Reactions with the `identifier` field currently not supported in evaluation"
 )
+PREDICTIONS_JSONL = "predictions.jsonl"
+STATS_JSON = "stats.json"
 
 
 @dataclass
@@ -82,12 +87,13 @@ class BaseEvalConfig:
 
     # Fields for saving and printing results
     print_idxs: List[int] = field(default_factory=lambda: [1, 3, 5, 10, 20, 50])
-    save_outputs: bool = True  # Whether to save the results as a JSON file
+    save_outputs: bool = True  # Whether to save the results as a JSON/JSONL file
     include_predictions: bool = True  # Whether to include the full predictions lists
     results_dir: str = field(
         default_factory=lambda: os.path.join(os.path.dirname(__file__), "results")
     )
     filestring: Optional[str] = None  # Unique string (appended to filename) to identify the run
+    resumable: bool = False  # Write predictions incrementally to allow resuming after interruption
 
     # Fields relevant to back translation
     back_translation_config: ForwardModelConfig = field(
@@ -198,6 +204,88 @@ def get_results(
     )
 
 
+@dataclass(frozen=True)
+class TimingRecord:
+    """Timing information for a single sample's model call."""
+
+    time_model_call: float
+    time_post_processing: float
+
+
+@dataclass(frozen=True)
+class PredictionRecord:
+    """Schema for a single row in the resumable predictions JSONL file."""
+
+    target: str
+    num_predictions: int
+    ground_truth_correct: List[bool]
+    timing: TimingRecord
+    stereo_correct: Optional[List[bool]] = None
+    back_translation_correct: Optional[List[bool]] = None
+    back_translation_timing: Optional[TimingRecord] = None
+    predictions: Optional[List[str]] = None
+    back_translation_predictions: Optional[List[List[str]]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a JSON-compatible dict, omitting unset optional fields."""
+        d: Dict[str, Any] = {
+            "target": self.target,
+            "num_predictions": self.num_predictions,
+            "ground_truth_correct": self.ground_truth_correct,
+            "timing": asdict(self.timing),
+        }
+        if self.stereo_correct is not None:
+            d["stereo_correct"] = self.stereo_correct
+        if self.back_translation_timing is not None:
+            d["back_translation_correct"] = self.back_translation_correct
+            d["back_translation_timing"] = asdict(self.back_translation_timing)
+        if self.predictions is not None:
+            d["predictions"] = self.predictions
+        if self.back_translation_predictions is not None:
+            d["back_translation_predictions"] = self.back_translation_predictions
+        return d
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "PredictionRecord":
+        """Deserialize from a JSON-loaded dict."""
+        bt_timing = d.get("back_translation_timing")
+        return cls(
+            target=d.get("target", ""),
+            num_predictions=d["num_predictions"],
+            ground_truth_correct=d["ground_truth_correct"],
+            timing=TimingRecord(**d["timing"]),
+            stereo_correct=d.get("stereo_correct"),
+            back_translation_correct=d.get("back_translation_correct"),
+            back_translation_timing=TimingRecord(**bt_timing) if bt_timing else None,
+            predictions=d.get("predictions"),
+            back_translation_predictions=d.get("back_translation_predictions"),
+        )
+
+
+def _reaction_from_smiles(rxn_smiles: str) -> Reaction:
+    """Reconstruct a Reaction from its reaction SMILES string."""
+    sep = REACTION_SEPARATOR * 2
+    reactants_str, products_str = rxn_smiles.split(sep)
+    reactants = Bag(Molecule(s) for s in reactants_str.split(SMILES_SEPARATOR) if s)
+    products = Bag(Molecule(s) for s in products_str.split(SMILES_SEPARATOR) if s)
+    return Reaction(reactants=reactants, products=products)
+
+
+def _load_and_fix_jsonl(path: Path) -> List[PredictionRecord]:
+    """Read a JSONL file, discarding any truncated trailing line, and re-write it clean."""
+    raw_dicts: List[Dict[str, Any]] = []
+    with open(path) as f:
+        for line in f:
+            try:
+                raw_dicts.append(json.loads(line))
+            except json.JSONDecodeError:
+                break
+    with open(path, "w") as f:
+        for d in raw_dicts:
+            f.write(json.dumps(d) + "\n")
+    return [PredictionRecord.from_dict(d) for d in raw_dicts]
+
+
 def compute_metrics(
     model: ReactionModel[InputType, ReactionType],
     dataset: ReactionDataset,
@@ -209,6 +297,8 @@ def compute_metrics(
     fold: DataFold = DataFold.VALIDATION,
     batch_size: int = 16,
     include_predictions: bool = False,
+    resumable: bool = False,
+    output_dir: Optional[Path] = None,
 ) -> EvalResults:
     """Compute top-k accuracies and Mean Reciprocal Rank of a model on a given dataset."""
 
@@ -261,6 +351,50 @@ def compute_metrics(
 
         test_dataset = islice(test_dataset, num_dataset_truncation)
         test_dataset_size = num_dataset_truncation
+
+    # Resume from partial JSONL if available.
+    num_already_done = 0
+    predictions_path = output_dir / PREDICTIONS_JSONL if resumable and output_dir else None
+    if predictions_path is not None and predictions_path.exists():
+        valid_records = _load_and_fix_jsonl(predictions_path)
+        for rec in valid_records:
+            ground_truth_match_metrics.add(rec.ground_truth_correct)
+            if include_results_modulo_stereo:
+                assert rec.stereo_correct is not None
+                ground_truth_match_modulo_stereo_metrics.add(rec.stereo_correct)
+            if back_translation_model is not None:
+                assert rec.back_translation_correct is not None
+                back_translation_metrics.add(rec.back_translation_correct)
+            num_predictions.append(rec.num_predictions)
+            model_timing_results.append(
+                ModelTimingResults(
+                    time_model_call=rec.timing.time_model_call,
+                    time_post_processing=rec.timing.time_post_processing,
+                )
+            )
+            if rec.back_translation_timing is not None:
+                back_translation_timing_results.append(
+                    ModelTimingResults(
+                        time_model_call=rec.back_translation_timing.time_model_call,
+                        time_post_processing=rec.back_translation_timing.time_post_processing,
+                    )
+                )
+            if include_predictions and rec.predictions is not None:
+                all_predictions.append([_reaction_from_smiles(s) for s in rec.predictions])
+            if include_predictions and rec.back_translation_predictions is not None:
+                all_back_translation_predictions.append(
+                    [
+                        [_reaction_from_smiles(s) for s in seq]
+                        for seq in rec.back_translation_predictions
+                    ]
+                )
+        num_already_done = len(valid_records)
+        if num_already_done > 0:
+            logger.info(f"Resumed: {num_already_done} samples already processed")
+            test_dataset = islice(test_dataset, num_already_done, None)
+            test_dataset_size -= num_already_done
+
+    jsonl_file = open(predictions_path, "a") if predictions_path else None
 
     for batch in tqdm(
         batched(test_dataset, batch_size),
@@ -318,14 +452,14 @@ def compute_metrics(
             for rxn, ground_truth_match in zip(reaction_list, ground_truth_matches):
                 rxn.metadata["ground_truth_match"] = ground_truth_match
 
+            stereo_matches: Optional[List[bool]] = None
             if include_results_modulo_stereo:
                 output_without_stereo = remove_stereo_information_from_reaction(output)
-                ground_truth_match_modulo_stereo_metrics.add(
-                    [
-                        remove_stereo_information_from_reaction(rxn) == output_without_stereo
-                        for rxn in reaction_list
-                    ]
-                )
+                stereo_matches = [
+                    remove_stereo_information_from_reaction(rxn) == output_without_stereo
+                    for rxn in reaction_list
+                ]
+                ground_truth_match_modulo_stereo_metrics.add(stereo_matches)
 
             if back_translation_model is not None:
                 assert back_translation_metrics is not None
@@ -356,9 +490,52 @@ def compute_metrics(
 
                 back_translation_metrics.add(back_translation_matches)
 
+            # Write incremental JSONL line for resumability.
+            if jsonl_file is not None:
+                batch_len = len(batch)
+                t = results_with_timing.model_timing_results
+                bt_correct: Optional[List[bool]] = None
+                bt_timing: Optional[TimingRecord] = None
+                bt_preds: Optional[List[List[str]]] = None
+                if back_translation_model is not None:
+                    bt = back_translation_results_with_timing.model_timing_results
+                    assert bt is not None
+                    bt_correct = back_translation_matches
+                    bt_timing = TimingRecord(
+                        time_model_call=bt.time_model_call / batch_len,
+                        time_post_processing=bt.time_post_processing / batch_len,
+                    )
+                    if include_predictions:
+                        bt_preds = [
+                            [rxn.reaction_smiles for rxn in seq] for seq in back_translation_results
+                        ]
+                record = PredictionRecord(
+                    target=output.reaction_smiles,
+                    num_predictions=len(reaction_list),
+                    ground_truth_correct=ground_truth_matches,
+                    timing=TimingRecord(
+                        time_model_call=t.time_model_call / batch_len,
+                        time_post_processing=t.time_post_processing / batch_len,
+                    ),
+                    stereo_correct=stereo_matches,
+                    back_translation_correct=bt_correct,
+                    back_translation_timing=bt_timing,
+                    predictions=(
+                        [rxn.reaction_smiles for rxn in reaction_list]
+                        if include_predictions
+                        else None
+                    ),
+                    back_translation_predictions=bt_preds,
+                )
+                jsonl_file.write(json.dumps(record.to_dict()) + "\n")
+                jsonl_file.flush()
+
         if include_predictions:
             all_predictions.extend(batch_predictions)
             all_back_translation_predictions.extend(batch_back_translation_predictions)
+
+    if jsonl_file is not None:
+        jsonl_file.close()
 
     extra_args: Dict[str, Any] = {}
 
@@ -405,6 +582,7 @@ def compute_metrics_from_config(
     dataset: ReactionDataset,
     back_translation_model: Optional[ForwardReactionModel],
     config: BaseEvalConfig,
+    output_dir: Optional[Path] = None,
 ) -> EvalResults:
     """Variant of `compute_metrics` that uses an eval config instead of explicit arguments."""
 
@@ -419,10 +597,14 @@ def compute_metrics_from_config(
         fold=config.fold,
         batch_size=config.batch_size,
         include_predictions=config.include_predictions,
+        resumable=config.resumable,
+        output_dir=output_dir,
     )
 
 
-def print_and_save(results: EvalResults, config: EvalConfig, suffix: str = "") -> None:
+def print_and_save(
+    results: EvalResults, config: EvalConfig, suffix: str = "", output_dir: Optional[Path] = None
+) -> None:
     chosen_top_k_results: Dict[str, Dict[int, List[float]]] = {}
 
     # Print the results in a concise form.
@@ -445,24 +627,33 @@ def print_and_save(results: EvalResults, config: EvalConfig, suffix: str = "") -
         for k, result in top_k.items():
             print(f"{k}: {result}", flush=True)
 
-    # Save the results into a json file, generate its name from the timestamp for uniqueness.
     if config.save_outputs:
-        filestr = ("_" + config.filestring) if config.filestring else ""
-        suffix = ("_" + suffix) if suffix else ""
-        timestamp = datetime.datetime.now().isoformat(timespec="seconds")
-
-        os.makedirs(config.results_dir, exist_ok=True)
-        outfile = os.path.join(
-            config.results_dir,
-            f"{config.model_class.name}_{str(timestamp)}{filestr}{suffix}.json",
-        )
         results_dict = asdict_extended(results)
-
         for key, top_k in chosen_top_k_results.items():
             results_dict[f"chosen_{key}"] = top_k
 
-        with open(outfile, "w") as outfile_stream:
-            outfile_stream.write(json.dumps(results_dict))
+        if config.resumable and output_dir is not None:
+            # In resumable mode, write stats separately (predictions are in the JSONL).
+            results_dict.pop("predictions", None)
+            results_dict.pop("back_translation_predictions", None)
+            stats_path = output_dir / STATS_JSON
+            with open(stats_path, "w") as stats_file:
+                stats_file.write(json.dumps(results_dict))
+            print(f"Stats saved to {stats_path}")
+            print(f"Predictions saved to {output_dir / PREDICTIONS_JSONL}")
+        else:
+            filestr = ("_" + config.filestring) if config.filestring else ""
+            suffix = ("_" + suffix) if suffix else ""
+            timestamp = datetime.datetime.now().isoformat(timespec="seconds")
+
+            os.makedirs(config.results_dir, exist_ok=True)
+            outfile = os.path.join(
+                config.results_dir,
+                f"{config.model_class.name}_{str(timestamp)}{filestr}{suffix}.json",
+            )
+
+            with open(outfile, "w") as outfile_stream:
+                outfile_stream.write(json.dumps(results_dict))
 
 
 def run_from_config(
@@ -482,6 +673,16 @@ def run_from_config(
             get_error_message_for_missing_value("model_class", [c.name for c in BackwardModelClass])
         )
 
+    # Set up resumable output directory if requested.
+    output_dir: Optional[Path] = None
+    if config.resumable:
+        filestr = ("_" + config.filestring) if config.filestring else ""
+        output_dir = Path(config.results_dir) / f"resumable_{config.fold.name}{filestr}"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if (output_dir / STATS_JSON).exists():
+            print(f"Evaluation already complete (results at {output_dir}), skipping")
+            return
+
     get_model_fn = partial(get_model, batch_size=config.batch_size, num_gpus=config.num_gpus)
     model = get_model_fn(config, remove_duplicates=config.skip_repeats)
 
@@ -495,9 +696,13 @@ def run_from_config(
 
     dataset = DiskReactionDataset(config.data_dir, sample_cls=ReactionSample)
     results = compute_metrics_from_config(
-        model=model, dataset=dataset, back_translation_model=back_translation_model, config=config
+        model=model,
+        dataset=dataset,
+        back_translation_model=back_translation_model,
+        config=config,
+        output_dir=output_dir,
     )
-    print_and_save(results, config)
+    print_and_save(results, config, output_dir=output_dir)
 
     for extra_step in extra_steps:
         extra_step(model, dataset, back_translation_model)

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -60,7 +60,7 @@ from syntheseus.reaction_prediction.utils.metrics import (
 from syntheseus.reaction_prediction.utils.misc import (
     asdict_extended,
     set_random_seed,
-    undictify_bag_of_molecules,
+    undictify_reaction,
 )
 from syntheseus.reaction_prediction.utils.model_loading import get_model
 
@@ -252,16 +252,6 @@ def _load_and_fix_jsonl(path: Path) -> List[PredictionRecord]:
     return [PredictionRecord.from_dict(d) for d in raw_dicts]
 
 
-def _reaction_from_dict(data: Dict[str, Any]) -> Reaction:
-    """Recover a reaction serialized with `asdict_extended`."""
-    return Reaction(
-        reactants=undictify_bag_of_molecules(data["reactants"]),
-        products=undictify_bag_of_molecules(data["products"]),
-        identifier=data.get("identifier"),
-        metadata=data.get("metadata", {}),
-    )
-
-
 def compute_metrics(
     model: ReactionModel[InputType, ReactionType],
     dataset: ReactionDataset,
@@ -346,11 +336,11 @@ def compute_metrics(
             if rec.back_translation_timing is not None:
                 back_translation_timing_results.append(rec.back_translation_timing)
             if include_predictions and rec.predictions is not None:
-                all_predictions.append([_reaction_from_dict(d) for d in rec.predictions])
+                all_predictions.append([undictify_reaction(d) for d in rec.predictions])
             if include_predictions and rec.back_translation_predictions is not None:
                 all_back_translation_predictions.append(
                     [
-                        [_reaction_from_dict(d) for d in seq]
+                        [undictify_reaction(d) for d in seq]
                         for seq in rec.back_translation_predictions
                     ]
                 )

--- a/syntheseus/interface/reaction.py
+++ b/syntheseus/interface/reaction.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Optional, TypedDict
 
 from syntheseus.interface.bag import Bag
-from syntheseus.interface.molecule import Molecule, molecule_bag_to_smiles
+from syntheseus.interface.molecule import SMILES_SEPARATOR, Molecule, molecule_bag_to_smiles
 
 REACTION_SEPARATOR = ">"
 
@@ -61,6 +61,15 @@ class Reaction:
     @property
     def reaction_smiles(self) -> str:
         return reaction_string(reactants_str=self.reactants_str, products_str=self.products_str)
+
+    @classmethod
+    def from_reaction_smiles(cls, rxn_smiles: str) -> "Reaction":
+        """Construct a Reaction from a reaction SMILES string (e.g. ``"A.B>>C"``)."""
+        sep = REACTION_SEPARATOR * 2
+        reactants_str, products_str = rxn_smiles.split(sep)
+        reactants = Bag(Molecule(s) for s in reactants_str.split(SMILES_SEPARATOR))
+        products = Bag(Molecule(s) for s in products_str.split(SMILES_SEPARATOR))
+        return cls(reactants=reactants, products=products)
 
     def __str__(self) -> str:
         output = self.reaction_smiles

--- a/syntheseus/reaction_prediction/data/reaction_sample.py
+++ b/syntheseus/reaction_prediction/data/reaction_sample.py
@@ -65,3 +65,10 @@ class ReactionSample(Reaction):
             reagents=SMILES_SEPARATOR.join(sorted(reagents_smiles)),
             **kwargs,
         )
+
+    @classmethod
+    def from_reaction_smiles(cls: Type[ReactionType], *args, **kwargs) -> Optional[ReactionType]:  # type: ignore[override]
+        try:
+            return cls.from_reaction_smiles_strict(*args, **kwargs)
+        except Exception:
+            return None

--- a/syntheseus/reaction_prediction/data/reaction_sample.py
+++ b/syntheseus/reaction_prediction/data/reaction_sample.py
@@ -65,10 +65,3 @@ class ReactionSample(Reaction):
             reagents=SMILES_SEPARATOR.join(sorted(reagents_smiles)),
             **kwargs,
         )
-
-    @classmethod
-    def from_reaction_smiles(cls: Type[ReactionType], *args, **kwargs) -> Optional[ReactionType]:
-        try:
-            return cls.from_reaction_smiles_strict(*args, **kwargs)
-        except Exception:
-            return None

--- a/syntheseus/reaction_prediction/utils/misc.py
+++ b/syntheseus/reaction_prediction/utils/misc.py
@@ -14,6 +14,7 @@ from rdkit import rdBase
 
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.molecule import Molecule
+from syntheseus.interface.reaction import Reaction
 
 
 def set_random_seed(seed: int = 0) -> None:
@@ -96,6 +97,16 @@ def asdict_extended(data) -> Dict[str, Any]:
 def undictify_bag_of_molecules(data: List[Dict[str, str]]) -> Bag[Molecule]:
     """Recovers a bag of molecules serialized with `dictify`."""
     return Bag(Molecule(d["smiles"]) for d in data)
+
+
+def undictify_reaction(data: Dict[str, Any]) -> Reaction:
+    """Recovers a reaction serialized with `dictify`/`asdict_extended`."""
+    return Reaction(
+        reactants=undictify_bag_of_molecules(data["reactants"]),
+        products=undictify_bag_of_molecules(data["products"]),
+        identifier=data.get("identifier"),
+        metadata=data.get("metadata", {}),
+    )
 
 
 def parallelize(

--- a/syntheseus/tests/cli/test_eval_single_step.py
+++ b/syntheseus/tests/cli/test_eval_single_step.py
@@ -11,7 +11,6 @@ from syntheseus.cli.eval_single_step import (
     EvalConfig,
     EvalResults,
     PredictionRecord,
-    TimingRecord,
     compute_metrics,
     get_results,
     print_and_save,
@@ -223,7 +222,7 @@ def test_resumable_writes_jsonl(tmp_path: Path) -> None:
         assert isinstance(rec.input, str) and len(rec.input) > 0
         assert isinstance(rec.ground_truth, str) and len(rec.ground_truth) > 0
         assert isinstance(rec.num_predictions, int)
-        assert isinstance(rec.timing, TimingRecord)
+        assert isinstance(rec.timing, ModelTimingResults)
 
 
 def test_resume_after_interrupt(tmp_path: Path) -> None:

--- a/syntheseus/tests/cli/test_eval_single_step.py
+++ b/syntheseus/tests/cli/test_eval_single_step.py
@@ -1,13 +1,17 @@
+import json
 import math
 from itertools import cycle, islice
 from pathlib import Path
-from typing import Iterable, List, Sequence
+from typing import Iterable, List, Optional, Sequence
 
 import pytest
 
 from syntheseus.cli.eval_single_step import (
+    PREDICTIONS_JSONL,
     EvalConfig,
     EvalResults,
+    PredictionRecord,
+    TimingRecord,
     compute_metrics,
     get_results,
     print_and_save,
@@ -170,3 +174,131 @@ def test_print_and_save(tmp_path: Path) -> None:
     )
 
     print_and_save(results, config)
+
+
+def _make_dataset_and_run(
+    tmp_path: Path,
+    resumable: bool = False,
+    num_top_results: int = 4,
+    num_dataset_truncation: int = 3,
+    output_dir: Optional[Path] = None,
+    include_predictions: bool = False,
+) -> EvalResults:
+    """Helper: creates a 3-sample backward dataset and runs compute_metrics."""
+    samples = [
+        ReactionSample.from_reaction_smiles_strict(f"{inp}>>{out}", mapped=False)
+        for inp, out in [("C.N", "CN"), ("NC=O", "CN"), ("C.C", "CC")]
+    ]
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(exist_ok=True)
+    for fold in DataFold:
+        DiskReactionDataset.save_samples_to_file(data_dir=data_dir, fold=fold, samples=samples)
+
+    return compute_metrics(
+        model=DummyModel(is_forward=False, repeat=False),
+        dataset=DiskReactionDataset(data_dir, sample_cls=ReactionSample),
+        num_dataset_truncation=num_dataset_truncation,
+        num_top_results=num_top_results,
+        resumable=resumable,
+        output_dir=output_dir,
+        include_predictions=include_predictions,
+    )
+
+
+def test_resumable_writes_jsonl(tmp_path: Path) -> None:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    results = _make_dataset_and_run(tmp_path, resumable=True, output_dir=output_dir)
+    predictions_path = output_dir / PREDICTIONS_JSONL
+    assert predictions_path.exists()
+
+    with open(predictions_path) as f:
+        lines = [line for line in f if line.strip()]
+    assert len(lines) == results.num_samples
+
+    for line in lines:
+        rec = PredictionRecord.from_dict(json.loads(line))
+        assert isinstance(rec.target, str) and len(rec.target) > 0
+        assert isinstance(rec.num_predictions, int)
+        assert isinstance(rec.timing, TimingRecord)
+
+
+def test_resume_after_interrupt(tmp_path: Path) -> None:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    full_results = _make_dataset_and_run(
+        tmp_path, resumable=True, output_dir=output_dir, num_dataset_truncation=3
+    )
+
+    predictions_path = output_dir / PREDICTIONS_JSONL
+    with open(predictions_path) as f:
+        all_lines = [line for line in f if line.strip()]
+    assert len(all_lines) == 3
+
+    # Keep only the first line (simulate crash after 1 sample).
+    with open(predictions_path, "w") as f:
+        f.write(all_lines[0] + "\n")
+
+    resumed_results = _make_dataset_and_run(
+        tmp_path, resumable=True, output_dir=output_dir, num_dataset_truncation=3
+    )
+
+    assert resumed_results.num_samples == full_results.num_samples
+    assert math.isclose(resumed_results.mrr, full_results.mrr)
+    for k in range(len(full_results.top_k)):
+        assert math.isclose(resumed_results.top_k[k], full_results.top_k[k])
+
+    with open(predictions_path) as f:
+        assert len([line for line in f if line.strip()]) == 3
+
+
+def test_metrics_consistency(tmp_path: Path) -> None:
+    """Resumable and non-resumable runs should produce the same metrics."""
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    non_resumable = _make_dataset_and_run(tmp_path, resumable=False)
+    resumable_results = _make_dataset_and_run(tmp_path, resumable=True, output_dir=output_dir)
+
+    assert non_resumable.num_samples == resumable_results.num_samples
+    assert math.isclose(non_resumable.mrr, resumable_results.mrr)
+    for k in range(len(non_resumable.top_k)):
+        assert math.isclose(non_resumable.top_k[k], resumable_results.top_k[k])
+
+
+def test_resume_with_predictions(tmp_path: Path) -> None:
+    """Resumable runs with include_predictions should restore predictions on resume."""
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    full_results = _make_dataset_and_run(
+        tmp_path,
+        resumable=True,
+        output_dir=output_dir,
+        num_dataset_truncation=3,
+        include_predictions=True,
+    )
+    assert full_results.predictions is not None
+    assert len(full_results.predictions) == 3
+
+    # Simulate crash after 1 sample.
+    predictions_path = output_dir / PREDICTIONS_JSONL
+    with open(predictions_path) as f:
+        all_lines = [line for line in f if line.strip()]
+    with open(predictions_path, "w") as f:
+        f.write(all_lines[0] + "\n")
+
+    resumed_results = _make_dataset_and_run(
+        tmp_path,
+        resumable=True,
+        output_dir=output_dir,
+        num_dataset_truncation=3,
+        include_predictions=True,
+    )
+    assert resumed_results.predictions is not None
+    assert len(resumed_results.predictions) == 3
+    assert resumed_results.num_samples == full_results.num_samples
+    assert math.isclose(resumed_results.mrr, full_results.mrr)

--- a/syntheseus/tests/cli/test_eval_single_step.py
+++ b/syntheseus/tests/cli/test_eval_single_step.py
@@ -220,7 +220,8 @@ def test_resumable_writes_jsonl(tmp_path: Path) -> None:
 
     for line in lines:
         rec = PredictionRecord.from_dict(json.loads(line))
-        assert isinstance(rec.target, str) and len(rec.target) > 0
+        assert isinstance(rec.input, str) and len(rec.input) > 0
+        assert isinstance(rec.ground_truth, str) and len(rec.ground_truth) > 0
         assert isinstance(rec.num_predictions, int)
         assert isinstance(rec.timing, TimingRecord)
 


### PR DESCRIPTION
This PR (attempts to) makes the `syntheseus/cli/eval_single_step.py` script resumable, mitigating the impact of e.g. job crashes/pre-emption.

To do this, the script now saves model inputs+outputs+information in a [`JSON Lines`](https://jsonlines.org/) file during evaluation.  Re-invoking this script after e.g. pre-emption/restarts attempts to load this file if available, and skips calling the model for any already-queried inputs.

The new output format is easier to work with than the existing `stats.json` files, since you can load line-by-line (see attached script and analysis for what this looks like).

To preserve backwards compatibility, this feature is hidden behind the `config.resumable` flag, which is turned off by default.

Thank you to @kmaziarz for the suggested implementation.