### PR TITLE
Run `apt-get update` in CI before installing `graphviz`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         environment-file: environment_full.yml
     - name: Install syntheseus with all single-step models
       run: |
+        sudo apt-get update
         sudo apt install -y graphviz
         pip install .[all]
     - name: Verify GPU is available


### PR DESCRIPTION
Recently, our CI started failing from `main`, due to an inability to install `graphviz`. This seems to be due to a stale apt cache. This PR fixes this by having CI do `apt-get update` before trying to install `graphviz`.