### PR TITLE
Pass molecule creation options through `molecule_bag_to_smiles`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Implement resumability for single-step evaluations ([#149](https://github.com/microsoft/syntheseus/pull/149)) ([@jla-gardner])
 - Add abstractions for filtering backward model proposals ([#151](https://github.com/microsoft/syntheseus/pull/151)) ([@kmaziarz])
+- Pass molecule creation options through `molecule_bag_to_smiles` ([#152](https://github.com/microsoft/syntheseus/pull/152)) ([@kmaziarz])
 
 ## [0.7.2] - 2026-01-30
 

--- a/syntheseus/reaction_prediction/chem/utils.py
+++ b/syntheseus/reaction_prediction/chem/utils.py
@@ -49,13 +49,13 @@ def remove_stereo_information_from_reaction(reaction: ReactionType) -> ReactionT
     )
 
 
-def molecule_bag_from_smiles_strict(smiles: str) -> Bag[Molecule]:
-    return Bag([Molecule(component) for component in smiles.split(SMILES_SEPARATOR)])
+def molecule_bag_from_smiles_strict(smiles: str, **kwargs) -> Bag[Molecule]:
+    return Bag([Molecule(component, **kwargs) for component in smiles.split(SMILES_SEPARATOR)])
 
 
-def molecule_bag_from_smiles(smiles: str) -> Optional[Bag[Molecule]]:
+def molecule_bag_from_smiles(smiles: str, **kwargs) -> Optional[Bag[Molecule]]:
     try:
-        return molecule_bag_from_smiles_strict(smiles)
+        return molecule_bag_from_smiles_strict(smiles, **kwargs)
     except ValueError:
         # If any of the components ends up invalid we return `None` instead.
         return None


### PR DESCRIPTION
This PR allows for passing in `Molecule` kwargs (e.g. `make_rdkit_mol`) when these are made through the `molecule_bag_to_smiles` and `molecule_bag_to_smiles_strict` utilities.