### PR TITLE
Make model tests more scalable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
       run: |
         nvidia-smi || (echo "❌ No GPU detected" && exit 1)
         python -c "import torch; assert torch.cuda.is_available(), '❌ GPU not found'; print('✅ Found GPU:', torch.cuda.get_device_name(0))"
+    - name: Cache model checkpoints
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/torch/syntheseus
+        key: model-checkpoints-${{ hashFiles('syntheseus/reaction_prediction/inference/default_checkpoint_ids.yml') }}
     - name: Run single-step model tests
       run: |
         coverage run -p -m pytest \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ viz = [
 dev = [
   "pytest",
   "pytest-cov",
+  "pytest-forked",
   "pytest-rerunfailures",
   "pre-commit"
 ]

--- a/syntheseus/tests/cli/test_cli.py
+++ b/syntheseus/tests/cli/test_cli.py
@@ -1,6 +1,7 @@
 import glob
 import json
 import math
+import subprocess
 import sys
 import tempfile
 import urllib
@@ -8,7 +9,6 @@ import zipfile
 from pathlib import Path
 from typing import Generator, List
 
-import omegaconf
 import pytest
 
 from syntheseus.reaction_prediction.inference.config import BackwardModelClass
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-MODEL_CLASSES_TO_TEST = set(BackwardModelClass) - {BackwardModelClass.GLN}
+MODEL_CLASSES_TO_TEST = [m for m in BackwardModelClass if m is not BackwardModelClass.GLN]
 
 
 @pytest.fixture(scope="module")
@@ -66,12 +66,13 @@ def search_cli_argv() -> List[str]:
 
 
 def run_cli_with_argv(argv: List[str]) -> None:
-    # The import below pulls in some optional dependencies, so do it locally to avoid executing it
-    # if the test suite is being skipped.
-    from syntheseus.cli.main import main
+    # Run in a subprocess so that model memory is fully reclaimed after each test.
+    result = subprocess.run(
+        [sys.executable, "-m", "syntheseus.cli.main"] + argv, capture_output=True, text=True
+    )
 
-    sys.argv = ["syntheseus"] + argv
-    main()
+    if result.returncode != 0:
+        raise RuntimeError("CLI failed")
 
 
 def test_cli_invalid(
@@ -103,7 +104,7 @@ def test_cli_invalid(
     ]
 
     for argv in argv_lists:
-        with pytest.raises((ValueError, omegaconf.errors.MissingMandatoryValue)):
+        with pytest.raises(RuntimeError):
             run_cli_with_argv(argv)
 
 

--- a/syntheseus/tests/conftest.py
+++ b/syntheseus/tests/conftest.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from syntheseus.interface.bag import Bag
 from syntheseus.interface.molecule import Molecule
 from syntheseus.interface.reaction import SingleProductReaction
+
+# Make `torch.cuda.is_available()` fork-safe so that calling it in the parent process does not
+# poison `@pytest.mark.forked` tests (otherwise could run into CUDA reinitialization issues).
+os.environ.setdefault("PYTORCH_NVML_BASED_CUDA_CHECK", "1")
 
 
 @pytest.fixture

--- a/syntheseus/tests/reaction_prediction/inference/test_models.py
+++ b/syntheseus/tests/reaction_prediction/inference/test_models.py
@@ -12,15 +12,16 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-MODEL_CLASSES_TO_TEST = set(BackwardModelClass) - {BackwardModelClass.GLN}
+MODEL_CLASSES_TO_TEST = [m for m in BackwardModelClass if m is not BackwardModelClass.GLN]
 
 
-@pytest.fixture(scope="module", params=list(MODEL_CLASSES_TO_TEST) * 2)
+@pytest.fixture(params=MODEL_CLASSES_TO_TEST)
 def model(request) -> ExternalBackwardReactionModel:
     model_cls = request.param.value
     return model_cls()
 
 
+@pytest.mark.forked
 def test_call(model: ExternalBackwardReactionModel) -> None:
     [result] = model([Molecule("Cc1ccc(-c2ccc(C)cc2)cc1")], num_results=20)
     model_predictions = [prediction.reactants for prediction in result]

--- a/syntheseus/tests/reaction_prediction/inference/test_models.py
+++ b/syntheseus/tests/reaction_prediction/inference/test_models.py
@@ -35,9 +35,9 @@ def test_call(model: ExternalBackwardReactionModel) -> None:
     # The model should recover at least two (out of six) in its top-20.
     assert len(set(expected_predictions) & set(model_predictions)) >= 2
 
-
-def test_misc(model: ExternalBackwardReactionModel) -> None:
     import torch
+
+    # Additionally test some misc properties and methods.
 
     assert isinstance(model.name, str)
     assert isinstance(model.get_model_info(), dict)


### PR DESCRIPTION
With the upcoming integration of new models from RetroChimera, I found that the way we currently run single-step models tests does not scale, especially when larger models are included. First, we've been running tests for all models in a single process, which meant all models are loaded simultaneously; this is inherently bounded by total memory available on the CI runners. Second, downloading many heavy model checkpoints is slow, and has a large variance. This PR attempts to resolve both issues to enable scaling to more single-step models in the future.

To avoid keeping all models in memory simultaneously, one could try forcing garbage collection, but this does not clean up all state, especially for models that involve multiprocessing or call into non-Python-native libraries. This PR instead proposes to run the tests in separate processes, which ensures all state is cleaned up. Previously, in `test_models.py` we used to test every model twice, to also test that loading one model doesn't make another model unusable; in the new setup, this wouldn't make sense, as models are now completely separate. We do lose a bit of test coverage as we do not test interactions between the models, but doing so exhaustively would not scale anyway; also, for the majority of usecases, only one model is used at a time. Finally, to reduce the burden of downloading model checkpoints, I use the `cache` action to cache the checkpoint directory (keyed on the contents of `default_checkpoint_ids.yml`), so that CI runs that don't add new models or change existing ones can benefit from much faster checkpoint download.