### PR TITLE
Improve resumable single-step eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Implement resumability for single-step evaluations ([#149](https://github.com/microsoft/syntheseus/pull/149)) ([@jla-gardner])
+- Implement resumability for single-step evaluations ([#149](https://github.com/microsoft/syntheseus/pull/149), [#155](https://github.com/microsoft/syntheseus/pull/155)) ([@jla-gardner], [@kmaziarz])
 - Add abstractions for filtering backward model proposals ([#151](https://github.com/microsoft/syntheseus/pull/151)) ([@kmaziarz])
 - Pass molecule creation options through `molecule_bag_to_smiles` ([#152](https://github.com/microsoft/syntheseus/pull/152)) ([@kmaziarz])
 

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -352,8 +352,6 @@ def compute_metrics(
             test_dataset = islice(test_dataset, num_already_done, None)
             test_dataset_size -= num_already_done
 
-    jsonl_file = open(predictions_path, "a") if predictions_path else None
-
     for batch in tqdm(
         batched(test_dataset, batch_size),
         total=math.ceil(test_dataset_size / batch_size),
@@ -457,7 +455,7 @@ def compute_metrics(
                 back_translation_metrics.add(back_translation_matches)
 
             # Write incremental JSONL line for resumability.
-            if jsonl_file is not None:
+            if predictions_path is not None:
                 batch_len = len(batch)
                 t = results_with_timing.model_timing_results
                 bt_correct: Optional[List[bool]] = None
@@ -493,15 +491,12 @@ def compute_metrics(
                     predictions=preds_for_output,
                     back_translation_predictions=bt_preds,
                 )
-                jsonl_file.write(json.dumps(record.to_dict()) + "\n")
-                jsonl_file.flush()
+                with open(predictions_path, "a") as jsonl_file:
+                    jsonl_file.write(json.dumps(record.to_dict()) + "\n")
 
         if include_predictions:
             all_predictions.extend(batch_predictions)
             all_back_translation_predictions.extend(batch_back_translation_predictions)
-
-    if jsonl_file is not None:
-        jsonl_file.close()
 
     extra_args: Dict[str, Any] = {}
 

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -347,6 +347,8 @@ def compute_metrics(
                     ]
                 )
         num_already_done = len(valid_records)
+        del valid_records
+
         if num_already_done > 0:
             logger.info(f"Resumed: {num_already_done} samples already processed")
             test_dataset = islice(test_dataset, num_already_done, None)

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -57,11 +57,7 @@ from syntheseus.reaction_prediction.utils.metrics import (
     TopKMetricsAccumulator,
     compute_total_time,
 )
-from syntheseus.reaction_prediction.utils.misc import (
-    asdict_extended,
-    set_random_seed,
-    undictify_reaction,
-)
+from syntheseus.reaction_prediction.utils.misc import asdict_extended, set_random_seed
 from syntheseus.reaction_prediction.utils.model_loading import get_model
 
 logger = logging.getLogger(__file__)
@@ -301,6 +297,10 @@ def compute_metrics(
 
     print(f"Testing model {model.__class__.__name__} with args {eval_args}")
 
+    # In resumable mode, predictions are already persisted in the JSONL file, so even if we want to
+    # include them, we don't need to gather them in memory.
+    store_predictions_in_memory = include_predictions and not resumable
+
     all_predictions: List[Sequence[Reaction]] = []
     all_back_translation_predictions: List[List[Sequence[Reaction]]] = []
 
@@ -337,15 +337,7 @@ def compute_metrics(
             model_timing_results.append(rec.timing)
             if rec.back_translation_timing is not None:
                 back_translation_timing_results.append(rec.back_translation_timing)
-            if include_predictions and rec.predictions is not None:
-                all_predictions.append([undictify_reaction(d) for d in rec.predictions])
-            if include_predictions and rec.back_translation_predictions is not None:
-                all_back_translation_predictions.append(
-                    [
-                        [undictify_reaction(d) for d in seq]
-                        for seq in rec.back_translation_predictions
-                    ]
-                )
+
         num_already_done = len(valid_records)
         del valid_records
 
@@ -496,13 +488,13 @@ def compute_metrics(
                 with open(predictions_path, "a") as jsonl_file:
                     jsonl_file.write(json.dumps(record.to_dict()) + "\n")
 
-        if include_predictions:
+        if store_predictions_in_memory:
             all_predictions.extend(batch_predictions)
             all_back_translation_predictions.extend(batch_back_translation_predictions)
 
     extra_args: Dict[str, Any] = {}
 
-    if include_predictions:
+    if store_predictions_in_memory:
         extra_args.update(predictions=all_predictions)
         extra_args.update(back_translation_predictions=all_back_translation_predictions)
 

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -240,15 +240,17 @@ class PredictionRecord:
 def _load_and_fix_jsonl(path: Path) -> List[PredictionRecord]:
     """Read a JSONL file, discarding any truncated trailing line, and re-write it clean."""
     raw_dicts: List[Dict[str, Any]] = []
-    with open(path) as f:
+    last_valid_pos = 0
+
+    with open(path, "rb") as f:
         for line in f:
             try:
                 raw_dicts.append(json.loads(line))
+                last_valid_pos = f.tell()
             except json.JSONDecodeError:
                 break
-    with open(path, "w") as f:
-        for d in raw_dicts:
-            f.write(json.dumps(d) + "\n")
+    with open(path, "r+b") as f:
+        f.truncate(last_valid_pos)
     return [PredictionRecord.from_dict(d) for d in raw_dicts]
 
 

--- a/syntheseus/tests/cli/test_eval_single_step.py
+++ b/syntheseus/tests/cli/test_eval_single_step.py
@@ -274,6 +274,12 @@ def test_resume_with_predictions(tmp_path: Path) -> None:
     output_dir = tmp_path / "output"
     output_dir.mkdir()
 
+    predictions_path = output_dir / PREDICTIONS_JSONL
+
+    def read_records() -> List[PredictionRecord]:
+        with open(predictions_path) as f:
+            return [PredictionRecord.from_dict(json.loads(line)) for line in f if line.strip()]
+
     full_results = _make_dataset_and_run(
         tmp_path,
         resumable=True,
@@ -281,11 +287,18 @@ def test_resume_with_predictions(tmp_path: Path) -> None:
         num_dataset_truncation=3,
         include_predictions=True,
     )
-    assert full_results.predictions is not None
-    assert len(full_results.predictions) == 3
+
+    # In resumable mode predictions live in the file, not in the returned object.
+    assert full_results.predictions is None
+
+    records = read_records()
+    assert len(records) == 3
+
+    for rec in records:
+        assert rec.predictions is not None
+        assert len(rec.predictions) == rec.num_predictions
 
     # Simulate crash after 1 sample.
-    predictions_path = output_dir / PREDICTIONS_JSONL
     with open(predictions_path) as f:
         all_lines = [line for line in f if line.strip()]
     with open(predictions_path, "w") as f:
@@ -298,7 +311,13 @@ def test_resume_with_predictions(tmp_path: Path) -> None:
         num_dataset_truncation=3,
         include_predictions=True,
     )
-    assert resumed_results.predictions is not None
-    assert len(resumed_results.predictions) == 3
+    assert resumed_results.predictions is None
     assert resumed_results.num_samples == full_results.num_samples
     assert math.isclose(resumed_results.mrr, full_results.mrr)
+
+    # Predictions are still present in the file for all samples after resuming.
+    resumed_records = read_records()
+    assert len(resumed_records) == 3
+    for rec in resumed_records:
+        assert rec.predictions is not None
+        assert len(rec.predictions) == rec.num_predictions


### PR DESCRIPTION
This PR continues after #149 by improving the robustness of single-step eval, especially in cases when the storage backend does not save things immediately (e.g. mounted remote container).

The most important change is that the current version of resumable evals rewrites the results file upon a restart, which is potentially a very heavy operation, and one that can take a minute or so to get flushed to storage. I saw cases where results from the next couple of batches would be lost because of a race condition between the file rewrite and subsequent appends. This PR proposes to instead truncate the file to remove the potential broken lines instead of fully rewriting it. Moreover, I found that reopening the results file after each batch instead of keeping it open throughout can lead to more frequent flushing to underlying storage. Finally, if running in resumable mode, `all_predictions` and `all_back_translation_predictions` were keeping the results in memory unnecessarily, as there is no downstream consumer of that data and it is already stored in the results file itself; this is also cleaned up here.