### PR TITLE
Integrate RetroChimera

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     name: test-core (Python ${{ matrix.python-version }})
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0  # Fetch full history so setuptools_scm can determine version from tags
     - uses: conda-incubator/setup-miniconda@v3
       with:
         mamba-version: "*"
@@ -57,6 +59,8 @@ jobs:
     - name: Free extra disk space
       uses: jlumbroso/free-disk-space@main
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0  # Fetch full history so setuptools_scm can determine version from tags
     - uses: conda-incubator/setup-miniconda@v3
       with:
         mamba-version: "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Integrate the RetroChimera model ([#156](https://github.com/microsoft/syntheseus/pull/156)) ([@kmaziarz])
 - Implement resumability for single-step evaluations ([#149](https://github.com/microsoft/syntheseus/pull/149), [#155](https://github.com/microsoft/syntheseus/pull/155)) ([@jla-gardner], [@kmaziarz])
 - Add abstractions for filtering backward model proposals ([#151](https://github.com/microsoft/syntheseus/pull/151)) ([@kmaziarz])
 - Pass molecule creation options through `molecule_bag_to_smiles` ([#152](https://github.com/microsoft/syntheseus/pull/152)) ([@kmaziarz])

--- a/environment_full.yml
+++ b/environment_full.yml
@@ -8,13 +8,20 @@ channels:
 dependencies:
   - faiss-gpu                                   # RetroKNN
   - numpy
+  - pandas                                      # RetroChimera
   - pip>=25.2
+  - pyg==2.5.2                                  # RetroChimera
   - python==3.9.7
   - pytorch=2.2.2=py3.9_cuda12.1_cudnn8.9.2_0
-  - pytorch-lightning==2.2.2                    # Chemformer
-  - pytorch-scatter==2.1.2                      # RetroKNN
-  - rdchiral_cpp                                # MHNreact
-  - rdkit=2021.09.4
+  - pytorch-lightning==2.2.2                    # Chemformer, RetroChimera
+  - pytorch-sparse==0.6.18                      # RetroChimera
+  - pytorch-cluster==1.6.3                      # RetroChimera
+  - pytorch-scatter==2.1.2                      # RetroKNN, RetroChimera
+  - rdchiral_cpp                                # MHNreact, RetroChimera
+  - rdkit=2023.09.6
+  - scipy<1.12                                  # RetroChimera
+  - torchvision==0.17.2                         # RetroChimera
   - pip:
     - --find-links https://data.dgl.ai/wheels/torch-2.2/cu121/repo.html
     - dgl==2.4.0                                # LocalRetro, RetroKNN
+    - torchmetrics==1.5.1                       # Chemformer, RetroChimera

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,10 @@ local-retro = ["syntheseus-local-retro==0.5.0"]
 megan = ["syntheseus-megan==0.2.0"]
 mhn-react = ["syntheseus-mhnreact==1.0.0"]
 retro-knn = ["syntheseus[local-retro]"]
+retrochimera = ["retrochimera==1.2.0"]
 root-aligned = ["syntheseus-root-aligned==0.2.0"]
 all-single-step = [
-  "syntheseus[chemformer,graph2edits,local-retro,megan,mhn-react,retro-knn,root-aligned]"
+  "syntheseus[chemformer,graph2edits,local-retro,megan,mhn-react,retro-knn,retrochimera,root-aligned]"
 ]
 all = [
   "syntheseus[viz,dev,all-single-step]"

--- a/syntheseus/reaction_prediction/inference/__init__.py
+++ b/syntheseus/reaction_prediction/inference/__init__.py
@@ -10,6 +10,16 @@ from syntheseus.reaction_prediction.inference.toy_models import (
     LinearMoleculesToyModel,
     ListOfReactionsToyModel,
 )
+from syntheseus.reaction_prediction.utils.misc import get_unavailable_model_class
+
+# RetroChimera is directly built on top of syntheseus, so we import from it directly.
+try:
+    from retrochimera import RetroChimeraDeNovoModel, RetroChimeraEditModel, RetroChimeraModel
+except ImportError:
+    RetroChimeraDeNovoModel = get_unavailable_model_class("RetroChimeraDeNovoModel", "retrochimera")
+    RetroChimeraEditModel = get_unavailable_model_class("RetroChimeraEditModel", "retrochimera")
+    RetroChimeraModel = get_unavailable_model_class("RetroChimeraModel", "retrochimera")
+
 
 __all__ = [
     "ChemformerModel",
@@ -20,6 +30,9 @@ __all__ = [
     "LocalRetroModel",
     "MEGANModel",
     "MHNreactModel",
+    "RetroChimeraDeNovoModel",
+    "RetroChimeraEditModel",
+    "RetroChimeraModel",
     "RetroKNNModel",
     "RootAlignedModel",
 ]

--- a/syntheseus/reaction_prediction/inference/config.py
+++ b/syntheseus/reaction_prediction/inference/config.py
@@ -11,6 +11,9 @@ from syntheseus.reaction_prediction.inference import (
     LocalRetroModel,
     MEGANModel,
     MHNreactModel,
+    RetroChimeraDeNovoModel,
+    RetroChimeraEditModel,
+    RetroChimeraModel,
     RetroKNNModel,
     RootAlignedModel,
 )
@@ -27,6 +30,9 @@ class BackwardModelClass(Enum):
     LocalRetro = LocalRetroModel
     MEGAN = MEGANModel
     MHNreact = MHNreactModel
+    RetroChimeraDeNovo = RetroChimeraDeNovoModel
+    RetroChimeraEdit = RetroChimeraEditModel
+    RetroChimera = RetroChimeraModel
     RetroKNN = RetroKNNModel
     RootAligned = RootAlignedModel
 

--- a/syntheseus/reaction_prediction/inference/default_checkpoint_ids.yml
+++ b/syntheseus/reaction_prediction/inference/default_checkpoint_ids.yml
@@ -6,6 +6,9 @@ backward:
   LocalRetro: 23960745
   MEGAN: 23960748
   MHNreact: 23960766
+  RetroChimera: 30591107
+  RetroChimeraDeNovo: 31150195
+  RetroChimeraEdit: 31150312
   RetroKNN: 23960769
   RootAligned: 23960781
 forward:

--- a/syntheseus/reaction_prediction/utils/misc.py
+++ b/syntheseus/reaction_prediction/utils/misc.py
@@ -144,3 +144,12 @@ def parallelize(
 def cpu_count(default: int = 8) -> int:
     """Return the number of CPUs, fallback to `default` if it cannot be determined."""
     return os.cpu_count() or default
+
+
+def get_unavailable_model_class(name: str, pkg: str) -> type:
+    """Returns a placeholder class that raises an `ImportError` on instantiation."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        raise ImportError(f"{name} cannot be instantiated because package '{pkg}' is not installed")
+
+    return type(name, (), {"__init__": __init__})

--- a/syntheseus/reaction_prediction/utils/testing.py
+++ b/syntheseus/reaction_prediction/utils/testing.py
@@ -10,6 +10,7 @@ def are_single_step_models_installed():
         import local_retro  # noqa: F401
         import megan  # noqa: F401
         import mhnreact  # noqa: F401
+        import retrochimera  # noqa: F401
         import root_aligned  # noqa: F401
 
         return True

--- a/syntheseus/tests/cli/test_cli.py
+++ b/syntheseus/tests/cli/test_cli.py
@@ -143,8 +143,15 @@ def test_cli_eval_single_step(
     assert 0.2 <= top_1_accuracy <= 0.8
 
 
-@pytest.mark.parametrize("model_class", MODEL_CLASSES_TO_TEST)
-@pytest.mark.parametrize("search_algorithm", ["retro_star", "mcts", "pdvn"])
+# Cycle through search algorithms across models instead of testing the full cross-product.
+_SEARCH_ALGORITHMS = ["retro_star", "mcts", "pdvn"]
+_SEARCH_TEST_CASES = [
+    (model_class, _SEARCH_ALGORITHMS[i % len(_SEARCH_ALGORITHMS)])
+    for i, model_class in enumerate(MODEL_CLASSES_TO_TEST)
+]
+
+
+@pytest.mark.parametrize("model_class,search_algorithm", _SEARCH_TEST_CASES)
 def test_cli_search(
     model_class: BackwardModelClass,
     search_algorithm: str,

--- a/syntheseus/tests/cli/test_cli.py
+++ b/syntheseus/tests/cli/test_cli.py
@@ -7,7 +7,7 @@ import tempfile
 import urllib
 import zipfile
 from pathlib import Path
-from typing import Generator, List
+from typing import Dict, Generator, List
 
 import pytest
 
@@ -22,6 +22,12 @@ pytestmark = pytest.mark.skipif(
 
 
 MODEL_CLASSES_TO_TEST = [m for m in BackwardModelClass if m is not BackwardModelClass.GLN]
+
+# Use a single rule application process for template-based models to reduce memory usage.
+EXTRA_CLI_ARGS: Dict[BackwardModelClass, List[str]] = {
+    BackwardModelClass.RetroChimeraEdit: ["model_kwargs.num_processes=1"],
+    BackwardModelClass.RetroChimera: ["model_kwargs.template_localization.num_processes=1"],
+}
 
 
 @pytest.fixture(scope="module")
@@ -122,6 +128,7 @@ def test_cli_eval_single_step(
             "print_idxs=[1,5]",
             "num_dataset_truncation=10",
         ]
+        + EXTRA_CLI_ARGS.get(model_class, [])
     )
 
     [results_path] = glob.glob(f"{tmpdir}/{model_class.name}_*.json")
@@ -156,6 +163,7 @@ def test_cli_search(
             "limit_iterations=3",
             "num_top_results=10",
         ]
+        + EXTRA_CLI_ARGS.get(model_class, [])
     )
 
     results_dir = f"{tmpdir}/{model_class.name}_*/"

--- a/syntheseus/tests/cli/test_cli.py
+++ b/syntheseus/tests/cli/test_cli.py
@@ -154,7 +154,7 @@ def test_cli_search(
             f"search_targets_file={data_dir}/search_targets.smiles",
             f"inventory_smiles_file={data_dir}/inventory.smiles",
             "limit_iterations=3",
-            "num_top_results=5",
+            "num_top_results=10",
         ]
     )
 

--- a/syntheseus/tests/reaction_prediction/inference/test_models.py
+++ b/syntheseus/tests/reaction_prediction/inference/test_models.py
@@ -14,11 +14,18 @@ pytestmark = pytest.mark.skipif(
 
 MODEL_CLASSES_TO_TEST = [m for m in BackwardModelClass if m is not BackwardModelClass.GLN]
 
+# Use a single rule application process for template-based models to reduce memory usage.
+RULE_SERVER_KWARGS = {"num_processes": 1}
+EXTRA_MODEL_KWARGS = {
+    BackwardModelClass.RetroChimeraEdit: RULE_SERVER_KWARGS,
+    BackwardModelClass.RetroChimera: {"template_localization": RULE_SERVER_KWARGS},
+}
+
 
 @pytest.fixture(params=MODEL_CLASSES_TO_TEST)
 def model(request) -> ExternalBackwardReactionModel:
     model_cls = request.param.value
-    return model_cls()
+    return model_cls(**EXTRA_MODEL_KWARGS.get(request.param, {}))
 
 
 @pytest.mark.forked


### PR DESCRIPTION
This PR integrates RetroChimera and its submodels as possible single-step model choices. Among other things, this required updating the environment file with additional dependencies. As the models tests became more expensive to run, I've also included several changes designed to curb this somewhat; in particular, we used to test a full cartesian product of possible model and algorithm combinations, and this PR instead proposes to test each model once while cycling through search algorithms.

Changes are split into logical commits for easier reviewing.