### PR TITLE
Enable forward model filtering in search CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 - Integrate the RetroChimera model ([#156](https://github.com/microsoft/syntheseus/pull/156), [#157](https://github.com/microsoft/syntheseus/pull/157)) ([@kmaziarz])
 - Implement resumability for single-step evaluations ([#149](https://github.com/microsoft/syntheseus/pull/149), [#155](https://github.com/microsoft/syntheseus/pull/155)) ([@jla-gardner], [@kmaziarz])
-- Add abstractions for filtering backward model proposals ([#151](https://github.com/microsoft/syntheseus/pull/151)) ([@kmaziarz])
+- Add support for filtering backward model proposals ([#151](https://github.com/microsoft/syntheseus/pull/151), [#159](https://github.com/microsoft/syntheseus/pull/159)) ([@kmaziarz])
 - Pass molecule creation options through `molecule_bag_to_smiles` ([#152](https://github.com/microsoft/syntheseus/pull/152)) ([@kmaziarz])
 - Add option to filter out reactions where the product is also one of the reactants ([#148](https://github.com/microsoft/syntheseus/pull/148)) ([@jla-gardner])
 

--- a/syntheseus/cli/eval_single_step.py
+++ b/syntheseus/cli/eval_single_step.py
@@ -638,7 +638,7 @@ def run_from_config(
             print(f"Evaluation already complete (results at {output_dir}), skipping")
             return
 
-    get_model_fn = partial(get_model, batch_size=config.batch_size, num_gpus=config.num_gpus)
+    get_model_fn = partial(get_model, num_gpus=config.num_gpus)
     model = get_model_fn(config, remove_duplicates=config.skip_repeats)
 
     if OmegaConf.is_missing(config.back_translation_config, "model_class"):

--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -31,7 +31,7 @@ import yaml
 from omegaconf import MISSING, DictConfig, OmegaConf
 from tqdm import tqdm
 
-from syntheseus import Molecule
+from syntheseus import BackwardReactionModel, ForwardReactionModel, Molecule
 from syntheseus.reaction_prediction.filters.forward import ForwardReactionFilterModel
 from syntheseus.reaction_prediction.filters.wrapper import FilteredBackwardReactionModel
 from syntheseus.reaction_prediction.inference.config import BackwardModelConfig, ForwardModelConfig
@@ -269,14 +269,15 @@ def run_from_config(config: SearchConfig) -> Path:
     )
 
     # Load the single-step model
-    search_rxn_model = get_model_fn(  # type: ignore
-        config, default_num_results=config.num_top_results
+    search_rxn_model = cast(
+        BackwardReactionModel,
+        get_model_fn(config, default_num_results=config.num_top_results),
     )
 
     # Optionally wrap the backward model with one or more filter models.
     filtering_enabled = not OmegaConf.is_missing(config.forward_filter, "model_class")
     if filtering_enabled:
-        forward_model = get_model_fn(config.forward_filter)
+        forward_model = cast(ForwardReactionModel, get_model_fn(config.forward_filter))
 
         forward_filter = ForwardReactionFilterModel(
             forward_model=forward_model,

--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -22,6 +22,7 @@ import pickle
 import statistics
 from dataclasses import dataclass, field
 from enum import Enum
+from functools import partial
 from pathlib import Path
 from pprint import pformat
 from typing import Any, Dict, Iterator, List, Optional, cast
@@ -31,7 +32,9 @@ from omegaconf import MISSING, DictConfig, OmegaConf
 from tqdm import tqdm
 
 from syntheseus import Molecule
-from syntheseus.reaction_prediction.inference.config import BackwardModelConfig
+from syntheseus.reaction_prediction.filters.forward import ForwardReactionFilterModel
+from syntheseus.reaction_prediction.filters.wrapper import FilteredBackwardReactionModel
+from syntheseus.reaction_prediction.inference.config import BackwardModelConfig, ForwardModelConfig
 from syntheseus.reaction_prediction.utils.config import get_config as cli_get_config
 from syntheseus.reaction_prediction.utils.misc import set_random_seed
 from syntheseus.reaction_prediction.utils.model_loading import get_model
@@ -181,6 +184,19 @@ def search_algorithm_config_to_kwargs(config: SearchAlgorithmConfig) -> Dict[str
 
 
 @dataclass
+class ForwardFilterConfig(ForwardModelConfig):
+    """Config for filtering backward model proposals via a forward reaction model."""
+
+    model_kwargs: Dict[str, Any] = field(default_factory=lambda: {"is_forward": True})
+
+    # Number of top forward predictions to check the proposed product against.
+    top_k: int = 5
+
+    # Extra kwargs forwarded to `ForwardReactionFilterModel`.
+    filter_kwargs: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
 class BaseSearchConfig(SearchAlgorithmConfig):
     # Molecule(s) to search for (either as a single explicit SMILES or a file)
     search_target: str = MISSING
@@ -200,6 +216,9 @@ class BaseSearchConfig(SearchAlgorithmConfig):
     # Fields configuring what to save after the run
     save_graph: bool = True  # Whether to save the full reaction graph (can be large)
     num_routes_to_plot: int = 5  # Number of routes to extract and plot for a quick check
+
+    # Optional filtering of backward model proposals via a forward model.
+    forward_filter: ForwardFilterConfig = field(default_factory=ForwardFilterConfig)
 
 
 @dataclass
@@ -243,13 +262,32 @@ def run_from_config(config: SearchConfig) -> Path:
             "Neither 'save_graph' nor 'num_routes_to_plot' is set; output saved will be minimal"
         )
 
-    # Load the single-step model
-    search_rxn_model = get_model(  # type: ignore
-        config,
+    get_model_fn = partial(
+        get_model,
         num_gpus=int(config.use_gpu),
         use_cache=config.reaction_model_use_cache,
-        default_num_results=config.num_top_results,
     )
+
+    # Load the single-step model
+    search_rxn_model = get_model_fn(  # type: ignore
+        config, default_num_results=config.num_top_results
+    )
+
+    # Optionally wrap the backward model with one or more filter models.
+    filtering_enabled = not OmegaConf.is_missing(config.forward_filter, "model_class")
+    if filtering_enabled:
+        forward_model = get_model_fn(config.forward_filter)
+
+        forward_filter = ForwardReactionFilterModel(
+            forward_model=forward_model,
+            top_k=config.forward_filter.top_k,
+            **cast(Dict[str, Any], OmegaConf.to_container(config.forward_filter.filter_kwargs)),
+        )
+
+        search_rxn_model = FilteredBackwardReactionModel(
+            backward_model=search_rxn_model,
+            filter_models={"forward": forward_filter},
+        )
 
     # Set up the inventory
     mol_inventory = SmilesListInventory.load_from_file(
@@ -351,6 +389,11 @@ def run_from_config(config: SearchConfig) -> Path:
             "soln_time_wallclock": soln_time_wallclock,
         }
 
+        if filtering_enabled:
+            assert isinstance(search_rxn_model, FilteredBackwardReactionModel)
+            stats["filter_acceptance_rate"] = search_rxn_model.acceptance_rate
+            stats["filter_acceptance_rate_per_filter"] = search_rxn_model.acceptance_rate_per_filter
+
         all_stats.append(stats)
         logger.info(pformat(stats))
 
@@ -392,7 +435,7 @@ def run_from_config(config: SearchConfig) -> Path:
 
     if num_targets > 1:
         logger.info(f"Writing summary statistics across all {num_targets} targets")
-        combined_stats: Dict[str, float] = dict(
+        combined_stats: Dict[str, Any] = dict(
             num_targets=num_targets,
             num_solved_targets=sum(stats["soln_time_wallclock"] != math.inf for stats in all_stats),
         )
@@ -406,6 +449,20 @@ def run_from_config(config: SearchConfig) -> Path:
             values = [stats[key] for stats in all_stats]
             combined_stats[f"average_{key}"] = statistics.mean(values)
             combined_stats[f"median_{key}"] = statistics.median(values)
+
+        if filtering_enabled:
+            acceptance_rates = [stats["filter_acceptance_rate"] for stats in all_stats]
+            combined_stats["average_filter_acceptance_rate"] = statistics.mean(acceptance_rates)
+            combined_stats["median_filter_acceptance_rate"] = statistics.median(acceptance_rates)
+
+            # Per-filter average across targets (filter names are identical for every target).
+            per_filter_keys = list(all_stats[0]["filter_acceptance_rate_per_filter"].keys())
+            combined_stats["average_filter_acceptance_rate_per_filter"] = {
+                name: statistics.mean(
+                    stats["filter_acceptance_rate_per_filter"][name] for stats in all_stats
+                )
+                for name in per_filter_keys
+            }
 
         logger.info(pformat(combined_stats))
 

--- a/syntheseus/cli/search.py
+++ b/syntheseus/cli/search.py
@@ -246,7 +246,6 @@ def run_from_config(config: SearchConfig) -> Path:
     # Load the single-step model
     search_rxn_model = get_model(  # type: ignore
         config,
-        batch_size=1,
         num_gpus=int(config.use_gpu),
         use_cache=config.reaction_model_use_cache,
         default_num_results=config.num_top_results,

--- a/syntheseus/reaction_prediction/utils/model_loading.py
+++ b/syntheseus/reaction_prediction/utils/model_loading.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Union
 
 from omegaconf import OmegaConf
@@ -6,14 +5,9 @@ from omegaconf import OmegaConf
 from syntheseus.interface.models import ReactionModel
 from syntheseus.reaction_prediction.inference.config import BackwardModelConfig, ForwardModelConfig
 
-logger = logging.getLogger(__file__)
-
 
 def get_model(
-    config: Union[BackwardModelConfig, ForwardModelConfig],
-    batch_size: int,
-    num_gpus: int,
-    **model_kwargs,
+    config: Union[BackwardModelConfig, ForwardModelConfig], num_gpus: int, **model_kwargs
 ) -> ReactionModel:
     # Check that model kwargs don't overlap
     overlapping_kwargs = set(config.model_kwargs.keys()) & set(model_kwargs.keys())
@@ -33,14 +27,6 @@ def get_model(
     elif num_gpus == 1:
         return model_fn("cuda:0")
     else:
-        if batch_size < num_gpus:
-            raise ValueError(f"Cannot split batch of size {batch_size} across {num_gpus} GPUs")
-
-        batch_size_per_gpu = batch_size // num_gpus
-
-        if batch_size_per_gpu < 16:
-            logger.warning(f"Batch size per GPU is very small: ~{batch_size_per_gpu}")
-
         try:
             from syntheseus.reaction_prediction.utils.parallel import ParallelReactionModel
         except ModuleNotFoundError:

--- a/syntheseus/tests/cli/test_cli.py
+++ b/syntheseus/tests/cli/test_cli.py
@@ -145,9 +145,7 @@ def test_cli_eval_single_step(
 
 # Prepare backward-forward model combinations. To keep the number of tests manageable, we first test
 # each backward model without forward, and then RetroChimera with each forward model as filter.
-_SEARCH_MODEL_COMBINATIONS = [
-    (model_class, None) for model_class in MODEL_CLASSES_TO_TEST
-] + [
+_SEARCH_MODEL_COMBINATIONS = [(model_class, None) for model_class in MODEL_CLASSES_TO_TEST] + [
     (BackwardModelClass.RetroChimera, model_class) for model_class in ForwardModelClass
 ]
 
@@ -160,9 +158,7 @@ _SEARCH_TEST_CASES = [
 ]
 
 
-@pytest.mark.parametrize(
-    "model_class,forward_model_class,search_algorithm", _SEARCH_TEST_CASES
-)
+@pytest.mark.parametrize("model_class,forward_model_class,search_algorithm", _SEARCH_TEST_CASES)
 def test_cli_search(
     model_class: BackwardModelClass,
     forward_model_class: Optional[ForwardModelClass],

--- a/syntheseus/tests/cli/test_cli.py
+++ b/syntheseus/tests/cli/test_cli.py
@@ -144,9 +144,10 @@ def test_cli_eval_single_step(
 
 
 # Prepare backward-forward model combinations. To keep the number of tests manageable, we first test
-# each backward model without forward, and then RetroChimera with each forward model as filter.
+# each backward model without forward, and then Graph2Edits with each forward model as filter. We
+# use Graph2Edits because it is both fast to load and not 100% feasible.
 _SEARCH_MODEL_COMBINATIONS = [(model_class, None) for model_class in MODEL_CLASSES_TO_TEST] + [
-    (BackwardModelClass.RetroChimera, model_class) for model_class in ForwardModelClass
+    (BackwardModelClass.Graph2Edits, model_class) for model_class in ForwardModelClass
 ]
 
 

--- a/syntheseus/tests/cli/test_cli.py
+++ b/syntheseus/tests/cli/test_cli.py
@@ -7,11 +7,11 @@ import tempfile
 import urllib
 import zipfile
 from pathlib import Path
-from typing import Dict, Generator, List
+from typing import Dict, Generator, List, Optional
 
 import pytest
 
-from syntheseus.reaction_prediction.inference.config import BackwardModelClass
+from syntheseus.reaction_prediction.inference.config import BackwardModelClass, ForwardModelClass
 from syntheseus.reaction_prediction.utils.downloading import get_figshare_download_link
 from syntheseus.reaction_prediction.utils.testing import are_single_step_models_installed
 
@@ -143,22 +143,39 @@ def test_cli_eval_single_step(
     assert 0.2 <= top_1_accuracy <= 0.8
 
 
-# Cycle through search algorithms across models instead of testing the full cross-product.
-_SEARCH_ALGORITHMS = ["retro_star", "mcts", "pdvn"]
-_SEARCH_TEST_CASES = [
-    (model_class, _SEARCH_ALGORITHMS[i % len(_SEARCH_ALGORITHMS)])
-    for i, model_class in enumerate(MODEL_CLASSES_TO_TEST)
+# Prepare backward-forward model combinations. To keep the number of tests manageable, we first test
+# each backward model without forward, and then RetroChimera with each forward model as filter.
+_SEARCH_MODEL_COMBINATIONS = [
+    (model_class, None) for model_class in MODEL_CLASSES_TO_TEST
+] + [
+    (BackwardModelClass.RetroChimera, model_class) for model_class in ForwardModelClass
 ]
 
 
-@pytest.mark.parametrize("model_class,search_algorithm", _SEARCH_TEST_CASES)
+# Cycle through search algorithms across models instead of testing the full cross-product.
+_SEARCH_ALGORITHMS = ["retro_star", "mcts", "pdvn"]
+_SEARCH_TEST_CASES = [
+    (*model_combination, _SEARCH_ALGORITHMS[i % len(_SEARCH_ALGORITHMS)])
+    for i, model_combination in enumerate(_SEARCH_MODEL_COMBINATIONS)
+]
+
+
+@pytest.mark.parametrize(
+    "model_class,forward_model_class,search_algorithm", _SEARCH_TEST_CASES
+)
 def test_cli_search(
     model_class: BackwardModelClass,
+    forward_model_class: Optional[ForwardModelClass],
     search_algorithm: str,
     data_dir: Path,
     tmpdir: Path,
     search_cli_argv: List[str],
 ) -> None:
+    forward_filter_args = (
+        [f"forward_filter.model_class={forward_model_class}", "forward_filter.top_k=10"]
+        if forward_model_class is not None
+        else []
+    )
     run_cli_with_argv(
         search_cli_argv
         + [
@@ -170,6 +187,7 @@ def test_cli_search(
             "limit_iterations=3",
             "num_top_results=10",
         ]
+        + forward_filter_args
         + EXTRA_CLI_ARGS.get(model_class, [])
     )
 
@@ -182,3 +200,12 @@ def test_cli_search(
     # Assert that a solution was found.
     assert results["soln_time_rxn_model_calls"] < math.inf
     assert len(glob.glob(f"{results_dir}/route_*.pdf")) >= 1
+
+    if forward_model_class is not None:
+        assert 0.1 <= results["filter_acceptance_rate"] <= 0.9
+        assert results["filter_acceptance_rate_per_filter"] == {
+            "forward": results["filter_acceptance_rate"]
+        }
+    else:
+        assert "filter_acceptance_rate" not in results
+        assert "filter_acceptance_rate_per_filter" not in results


### PR DESCRIPTION
In #151, we added initial abstractions for _filter models_: models capable of filtering down backward model proposals to improve overall reliability of explored synthesis paths. These abstractions were so far not connected to the actual search CLI. This PR does this for the forward model abstraction, for which we already have one integrated model class a user could choose (`ChemformerModel`).