### PR TITLE
Disable sharded repodata in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+env:
+  # Temporarily disable sharded repodata until fixed upstream.
+  MAMBA_USE_SHARDED_REPODATA: "false"
+
 jobs:
   test-core:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Recently, our CI started failing from `main`, with errors in mamba env resolution. This turns out to be related to the handling of repodata information by the newest version of `mamba`. This PR disables the new behaviour, reverting to the old resolution method (whose only disadvantage is being slightly slower). We can remove this later once the new behaviour is stable.